### PR TITLE
Enhance list manipulation blocks with new features and deprecations

### DIFF
--- a/smartspace/tests/test_aggregate_list_block.py
+++ b/smartspace/tests/test_aggregate_list_block.py
@@ -1,0 +1,59 @@
+import pytest
+
+from smartspace.blocks.lists import AggregateList
+
+
+@pytest.mark.asyncio
+async def test_aggregate_list_empty():
+    block = AggregateList()
+    result = await block.aggregate()
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_aggregate_list_single_item():
+    block = AggregateList()
+    result = await block.aggregate(1)
+    assert result == [1]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_list_multiple_items():
+    block = AggregateList()
+    result = await block.aggregate(1, 2, 3)
+    assert result == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_list_with_lists():
+    block = AggregateList()
+    result = await block.aggregate([1, 2], [3, 4])
+    assert result == [1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_mixed_types():
+    block = AggregateList()
+    result = await block.aggregate([1, 2], 3, [4, 5])
+    assert result == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_strings():
+    block = AggregateList()
+    result = await block.aggregate("a", "b", "c")
+    assert result == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_list_of_strings():
+    block = AggregateList()
+    result = await block.aggregate(["a", "b"], "c", ["d"])
+    assert result == ["a", "b", "c", "d"]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_list_of_lists():
+    block = AggregateList()
+    result = await block.aggregate([1, {"a": 1}], [3, 4])
+    assert result == [1, {"a": 1}, 3, 4]

--- a/smartspace/tests/test_slice_block.py
+++ b/smartspace/tests/test_slice_block.py
@@ -1,0 +1,79 @@
+import pytest
+
+from smartspace.blocks.lists import Slice
+
+
+@pytest.mark.asyncio
+async def test_slice_list_default():
+    block = Slice()
+    result = await block.slice([1, 2, 3, 4, 5])
+    assert result == []  # Default start=0, end=0 returns empty
+
+
+@pytest.mark.asyncio
+async def test_slice_list_with_end():
+    block = Slice()
+    block.end = 3
+    result = await block.slice([1, 2, 3, 4, 5])
+    assert result == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_slice_list_with_start():
+    block = Slice()
+    block.start = 2
+    block.end = 5
+    result = await block.slice([1, 2, 3, 4, 5])
+    assert result == [3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_slice_string():
+    block = Slice()
+    block.start = 1
+    block.end = 4
+    result = await block.slice("Hello World")
+    assert result == "ell"
+
+
+@pytest.mark.asyncio
+async def test_slice_empty_list():
+    block = Slice()
+    block.end = 3
+    result = await block.slice([])
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_slice_empty_string():
+    block = Slice()
+    block.end = 3
+    result = await block.slice("")
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_slice_negative_indices():
+    block = Slice()
+    block.start = -3
+    block.end = -1
+    result = await block.slice([1, 2, 3, 4, 5])
+    assert result == [3, 4]
+
+
+@pytest.mark.asyncio
+async def test_slice_with_list_input():
+    block = Slice()
+    block.start = 1
+    block.end = 1
+    result = await block.slice([1, 2, 3, 4, 5])
+    assert result == 2
+
+
+@pytest.mark.asyncio
+async def test_slice_with_string_input():
+    block = Slice()
+    block.start = 1
+    block.end = 1
+    result = await block.slice("Hello World")
+    assert result == "e"


### PR DESCRIPTION
- Update Slice block to support single-index retrieval
- Mark First block as deprecated with recommendation to use Slice
- Add new AggregateList block for combining items and sequences