### PR TITLE
  Fix GitHub Pages deployment configuration

### DIFF
--- a/.github/workflows/develop-docs.yml
+++ b/.github/workflows/develop-docs.yml
@@ -36,4 +36,6 @@ jobs:
         run: |
           git fetch origin gh-pages --depth=1 || true
       - name: Build Docs Website
-        run: poetry run mike deploy --push dev
+        run: |
+          poetry run mike deploy --push dev
+          poetry run mike alias dev latest --push

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Smartspace Workflow Documentation
-site_url: "https://redesigned-happiness-lml15p6.pages.github.io/"
-repo_url: "https://github.com/Smartspace-ai/smartspace-flows"
+site_url: "https://smartspace-ai.github.io/smartspace-sdk/"
+repo_url: "https://github.com/Smartspace-ai/smartspace-sdk"
 
 theme:
   features:


### PR DESCRIPTION
  - Update site_url in mkdocs.yml to correct GitHub Pages URL (https://smartspace-ai.github.io/smartspace-sdk/)
  - Fix repository URL to match actual repo name (smartspace-sdk)
  - Add 'latest' alias to 'dev' version in deployment workflow for better accessibility
  - Ensures documentation is accessible at both /dev/ and /latest/ paths