### PR TITLE
Downgrade lark dependency to version 1.1.9

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1499,13 +1499,13 @@ referencing = ">=0.31.0"
 
 [[package]]
 name = "lark"
-version = "1.2.2"
+version = "1.1.9"
 description = "a modern parsing library"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.6"
 files = [
-    {file = "lark-1.2.2-py3-none-any.whl", hash = "sha256:c2276486b02f0f1b90be155f2c8ba4a8e194d42775786db622faccd652d8e80c"},
-    {file = "lark-1.2.2.tar.gz", hash = "sha256:ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80"},
+    {file = "lark-1.1.9-py3-none-any.whl", hash = "sha256:a0dd3a87289f8ccbb325901e4222e723e7d745dbfc1803eaf5f3d2ace19cf2db"},
+    {file = "lark-1.1.9.tar.gz", hash = "sha256:15fa5236490824c2c4aba0e22d2d6d823575dcaf4cdd1848e34b6ad836240fba"},
 ]
 
 [package.extras]
@@ -5477,4 +5477,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "82d1f6542be4295e03874312f6a6217c216d3b84d6ef720bd56f4ec7bb56eb91"
+content-hash = "54cf0c8aba6c77252295470ec5f79585736d2042e4456acbd7571e552f893c18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ docxtpl = "^0.19.0"
 python-docx = "^1.1.2"
 aiomysql = "^0.2.0"
 llama-index-embeddings-huggingface = "^0.5.4"
-lark = "^1.2.2"
+lark = "1.1.9"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.0"


### PR DESCRIPTION
Changed the lark package version from ^1.2.2 to 1.1.9 in pyproject.toml and updated poetry.lock accordingly. This may be to address compatibility or stability issues with the newer version.