### PR TITLE
feat: add StreamingOutput pin for single-value progressive streams

### DIFF
--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -35,6 +35,7 @@ from smartspace.enums import (
     BlockScope,
     ChannelEvent,
     InputDisplayType,
+    StreamingEvent,
 )
 from smartspace.models import (
     BlockErrorModel,
@@ -48,6 +49,7 @@ from smartspace.models import (
     OutputChannelMessage,
     OutputPinInterface,
     OutputValue,
+    StreamingOutputMessage,
     PinRedirect,
     PinType,
     PortInterface,
@@ -171,16 +173,19 @@ def _get_function_pins(fn: Callable, port_name: str | None = None) -> FunctionPi
             {},
         )
 
-        if get_origin(signature.return_annotation) == OutputChannel:
+        return_origin = get_origin(signature.return_annotation)
+        if return_origin is OutputChannel or return_origin is StreamingOutput:
             args = get_args(signature.return_annotation)
             if not args or len(args) != 1:
                 raise Exception("Outputs must have exactly one type.")
 
             output_type: type = args[0]
-            is_channel = True
+            is_channel = return_origin is OutputChannel
+            is_streaming = return_origin is StreamingOutput
         else:
             output_type = signature.return_annotation
             is_channel = False
+            is_streaming = False
 
         output_type_adapter, schema, _generics = _get_json_schema_with_generics(
             output_type
@@ -201,6 +206,7 @@ def _get_function_pins(fn: Callable, port_name: str | None = None) -> FunctionPi
                 },
                 channel=is_channel,
                 channel_group_id=port_name if is_channel else None,
+                streaming=is_streaming,
             ),
             output_type_adapter,
         )
@@ -639,7 +645,7 @@ def _get_pins(
 
     for base_type in all_bases:
         o = get_origin(base_type)
-        if o is Output or o is OutputChannel:
+        if o is Output or o is OutputChannel or o is StreamingOutput:
             args = get_args(base_type)
             if not args or len(args) != 1:
                 raise Exception("Outputs must have exactly one type.")
@@ -656,6 +662,7 @@ def _get_pins(
                 },
                 channel=o is OutputChannel,
                 channel_group_id=f"{port_name}" if o is OutputChannel else None,
+                streaming=o is StreamingOutput,
             )
 
     if _issubclass(cls_annotation, Tool):
@@ -723,7 +730,7 @@ def _get_pins(
             field_type = field_annotation
 
         o = get_origin(field_type)
-        if o is Output or o is OutputChannel:
+        if o is Output or o is OutputChannel or o is StreamingOutput:
             args = get_args(field_type)
             if not args or len(args) != 1:
                 raise Exception("Outputs must have exactly one type.")
@@ -758,6 +765,7 @@ def _get_pins(
                 },
                 channel=o is OutputChannel,
                 channel_group_id=f"{port_name}.{name}" if o is OutputChannel else None,
+                streaming=o is StreamingOutput,
             )
 
         elif o is dict:
@@ -1208,6 +1216,67 @@ class Output(Generic[T]):
                     OutputValue(
                         source=self.pin,
                         value=value,
+                    )
+                ],
+                inputs=[],
+                redirects=[],
+                states=[],
+            )
+        )
+
+
+class StreamingOutput(Generic[T]):
+    """An output that represents a single logical value arriving in parts.
+
+    Call ``update(snapshot)`` repeatedly during streaming; each snapshot
+    supersedes the prior one and routes only to FlowOutputs for live UI
+    display. Call ``finalize(value)`` once to emit the terminal, authoritative
+    value, which routes to FlowOutputs, FlowVariables and downstream blocks.
+
+    After ``finalize`` is called, further ``update`` / ``finalize`` calls
+    are silently dropped — the pin is single-shot from the flow's
+    perspective.
+    """
+
+    def __init__(self, pin: BlockPinRef):
+        self.pin = pin
+        self._finalized = False
+
+    def update(self, snapshot: T):
+        if self._finalized:
+            return
+        messages = block_messages.get()
+        messages.put_nowait(
+            BlockRunMessage(
+                outputs=[
+                    OutputValue(
+                        source=self.pin,
+                        value=StreamingOutputMessage(
+                            event=StreamingEvent.UPDATE,
+                            data=snapshot,
+                        ),
+                    )
+                ],
+                inputs=[],
+                redirects=[],
+                states=[],
+            )
+        )
+
+    def finalize(self, value: T):
+        if self._finalized:
+            return
+        self._finalized = True
+        messages = block_messages.get()
+        messages.put_nowait(
+            BlockRunMessage(
+                outputs=[
+                    OutputValue(
+                        source=self.pin,
+                        value=StreamingOutputMessage(
+                            event=StreamingEvent.FINALIZE,
+                            data=value,
+                        ),
                     )
                 ],
                 inputs=[],
@@ -1781,6 +1850,8 @@ class Block(metaclass=MetaBlock):
             elif "" in port_interface.outputs:
                 if port_interface.outputs[""].channel:
                     return OutputChannel(BlockPinRef(port=port_id, pin=""))
+                elif port_interface.outputs[""].streaming:
+                    return StreamingOutput(BlockPinRef(port=port_id, pin=""))
                 else:
                     return Output(BlockPinRef(port=port_id, pin=""))
 
@@ -1851,6 +1922,10 @@ class Block(metaclass=MetaBlock):
             if output_interface.type == PinType.SINGLE:
                 if output_interface.channel:
                     output = OutputChannel(BlockPinRef(port=port_id, pin=output_name))
+                elif output_interface.streaming:
+                    output = StreamingOutput(
+                        BlockPinRef(port=port_id, pin=output_name)
+                    )
                 else:
                     output = Output(BlockPinRef(port=port_id, pin=output_name))
 
@@ -1865,13 +1940,17 @@ class Block(metaclass=MetaBlock):
                     for _output_name, index in dynamic_outputs
                     if _output_name == output_name
                 ]
-                outputs: list[None | Output | OutputChannel] = [None] * (
-                    max(_dynamic_outputs, default=-1) + 1
-                )
+                outputs: list[None | Output | OutputChannel | StreamingOutput] = [
+                    None
+                ] * (max(_dynamic_outputs, default=-1) + 1)
 
                 for index in _dynamic_outputs:
                     if output_interface.channel:
                         outputs[index] = OutputChannel(
+                            BlockPinRef(port=port_id, pin=output_name)
+                        )
+                    elif output_interface.streaming:
+                        outputs[index] = StreamingOutput(
                             BlockPinRef(port=port_id, pin=output_name)
                         )
                     else:
@@ -1887,10 +1966,19 @@ class Block(metaclass=MetaBlock):
                     )
 
             elif output_interface.type == PinType.DICTIONARY:
-                output_dict: dict[str, Output | OutputChannel] = {
-                    index: OutputChannel(BlockPinRef(port=port_id, pin=output_name))
-                    if output_interface.channel
-                    else Output(BlockPinRef(port=port_id, pin=output_name))
+                def _make_output(pin_ref: BlockPinRef):
+                    if output_interface.channel:
+                        return OutputChannel(pin_ref)
+                    if output_interface.streaming:
+                        return StreamingOutput(pin_ref)
+                    return Output(pin_ref)
+
+                output_dict: dict[
+                    str, Output | OutputChannel | StreamingOutput
+                ] = {
+                    index: _make_output(
+                        BlockPinRef(port=port_id, pin=output_name)
+                    )
                     for _output_name, index in dynamic_outputs
                     if _output_name == output_name
                 }

--- a/smartspace/enums.py
+++ b/smartspace/enums.py
@@ -30,6 +30,20 @@ class ChannelState(Enum):
     CLOSED = "Closed"
 
 
+class StreamingEvent(Enum):
+    """Events emitted by a StreamingOutput pin.
+
+    UPDATE   — progressive snapshot of a single logical value. Supersedes
+               any prior UPDATE on the same pin. Routes to FlowOutputs only
+               (compute consumers see the FINALIZE value).
+    FINALIZE — terminal, authoritative value. Fires once. Routes to
+               FlowOutputs, FlowVariables and downstream FlowBlocks.
+    """
+
+    UPDATE = "Update"
+    FINALIZE = "Finalize"
+
+
 class BlockScope(Enum):
     WORKSPACE = "WorkSpace"
     DATASET = "DataSet"

--- a/smartspace/models.py
+++ b/smartspace/models.py
@@ -11,6 +11,7 @@ from smartspace.enums import (
     ChannelEvent,
     ChannelState,
     FlowVariableAccess,
+    StreamingEvent,
 )
 from smartspace.utils.utils import _get_type_adapter
 
@@ -280,6 +281,10 @@ class OutputPinInterface(BaseModel):
     type: PinType
     channel: bool
     channel_group_id: Annotated[str | None, Field(alias="channelGroupId")]
+    # True for StreamingOutput pins: progressive snapshots of a single
+    # logical value, terminated by a FINALIZE event. Mutually exclusive
+    # with `channel` — a pin is a plain output, a channel, or streaming.
+    streaming: bool = False
 
 
 class PortInterface(BaseModel):
@@ -589,3 +594,20 @@ class OutputChannelMessage(BaseModel, Generic[ChannelT]):
 
     event: ChannelEvent | None
     data: ChannelT | None
+
+
+StreamingT = TypeVar("StreamingT")
+
+
+class StreamingOutputMessage(BaseModel, Generic[StreamingT]):
+    """Wire payload emitted by a StreamingOutput pin.
+
+    UPDATE carries a progressive snapshot; FINALIZE carries the terminal
+    value. The runtime discriminates on `event` to decide persistence and
+    routing semantics.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    event: StreamingEvent
+    data: StreamingT | None


### PR DESCRIPTION
## Summary

Adds a `StreamingOutput[T]` pin type for blocks that produce a single logical value progressively (e.g. an LLM response that arrives token-by-token). Distinct from `OutputChannel`, which models multiple discrete events with channel routing.

## Wire semantics

- `update(snapshot)` — emit a supersedable progressive snapshot. The runtime routes it to `FlowOutput` nodes only (for live UI display) and persists just the latest snapshot per pin.
- `finalize(value)` — emit the terminal authoritative value. Routes to `FlowOutput` + `FlowVariable` + downstream `FlowBlock` consumers and closes the pin. Subsequent `update()` calls are no-ops.

Unlike `OutputChannel`, the streaming pin does not participate in channel routing (no `channels` dict, no for-each combinatorial state) — it's a plain output with a supersedable-snapshot + finalize lifecycle.

## Changes

- `enums.StreamingEvent` — `UPDATE` / `FINALIZE`
- `models.StreamingOutputMessage` — wire payload (`event`, `data`)
- `models.OutputPinInterface` — gains `streaming: bool`
- `core.StreamingOutput` — class with `update()` / `finalize()` methods
- Block introspection and instantiation recognise `StreamingOutput` alongside `Output` and `OutputChannel`

## Consumer requirement

The runtime side (Smartspace-ai-api `feat/streaming-output-pin` branch) needs this SDK to import `StreamingOutput`, `StreamingEvent`, and `StreamingOutputMessage`. Should be released and pinned in the consumer's `pyproject.toml` before merging the runtime PR.

## Test plan

- [ ] Existing SDK tests pass (no behavioural changes to `Output` or `OutputChannel`)
- [ ] Consumer-side integration verified: `Smartspace-ai-api` `feat/streaming-output-pin` runs end-to-end with this SDK editable-installed (verified locally during development)
- [ ] Streaming integration test in consumer (`tests/smartspace_sdk/test_llm_block_streaming.py`) passes against real Azure Responses