### PR TITLE
chore(blocks): add Delay/Limit/Transform, new category taxonomy, label/desc gaps

### DIFF
--- a/smartspace/blocks/MarkdownToRTF.py
+++ b/smartspace/blocks/MarkdownToRTF.py
@@ -1,12 +1,13 @@
 import pypandoc
 
 from smartspace.core import Block, metadata, step
+from smartspace.enums import BlockCategory
 
 
 @metadata(
-    category={"name": "Custom", "description": "Custom blocks added by SmartSpace"},
+    category=BlockCategory.TRANSFORM,
     description="Converts Markdown input to RTF format.",
-    label="markdown-to-rtf converter",
+    label="markdown to rtf, format conversion, document conversion, pandoc",
 )
 class MarkdownToRTF(Block):
     @step(output_name="rtf_output")

--- a/smartspace/blocks/buffer.py
+++ b/smartspace/blocks/buffer.py
@@ -1,11 +1,13 @@
 from typing import Annotated, Any, Generic, TypeVar
 
 from smartspace.core import Block, Output, State, metadata, step
+from smartspace.enums import BlockCategory
 
 ValueT = TypeVar("ValueT")
 
 
 @metadata(
+    category=BlockCategory.TRANSFORM,
     description="Buffers values in a list and outputs them one at a time.",
     icon="fa-database",
     label="buffer, queue, buffer block, queue block, buffer list, queue list",

--- a/smartspace/blocks/cast_block.py
+++ b/smartspace/blocks/cast_block.py
@@ -11,7 +11,7 @@ ItemT = TypeVar("ItemT")
 
 @metadata(
     description="Takes in any input and will attempt to convert the input to the specified schema. If the convert config is unticked, it will not attempt to convert the value and will instead just output the input.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-sync-alt",
     label="cast type, convert data, transform format, change type, typecast value",
 )

--- a/smartspace/blocks/conditionals.py
+++ b/smartspace/blocks/conditionals.py
@@ -14,7 +14,7 @@ ValueT = TypeVar("ValueT")
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description=f"""Evaluates the input value using the configured condition.
 {expression_tooltip}""",
     label="conditional logic, boolean check, if-then-else, branching, condition evaluation",
@@ -43,7 +43,7 @@ class SwitchOption:
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description=f"""Evaluates the input value using the configured condition.
     {expression_tooltip}""",
     label="switch statement, case selection, multi-way branching, conditional routing, expression switch",
@@ -76,7 +76,7 @@ class Switch(Block, Generic[ValueT]):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description=f"""Filters a list of items using the configured condition.
 {expression_tooltip}""",
     label="list filtering, item selection, data subsetting, conditional filtering, collection filtering",

--- a/smartspace/blocks/const_blocks.py
+++ b/smartspace/blocks/const_blocks.py
@@ -6,7 +6,7 @@ from smartspace.enums import BlockCategory
 
 @metadata(
     description="Takes a dictionary as config and outputs it.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-book",
     label="dictionary constant, fixed dictionary, static object, constant map, predefined object",
 )
@@ -20,7 +20,7 @@ class DictConst(Block):
 
 @metadata(
     description="Takes a string as config and outputs it.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-quote-right",
     label="string constant, fixed text, static string, constant text, predefined string",
 )
@@ -34,7 +34,7 @@ class StringConst(Block):
 
 @metadata(
     description="Takes an integer as config and outputs it.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-hashtag",
     label="integer constant, fixed number, static integer, constant number, predefined value",
 )

--- a/smartspace/blocks/delay.py
+++ b/smartspace/blocks/delay.py
@@ -1,0 +1,29 @@
+import asyncio
+from typing import Annotated, Any
+
+from smartspace.core import Block, Config, Metadata, Output, metadata, step
+from smartspace.enums import BlockCategory
+
+
+@metadata(
+    category=BlockCategory.CONTROL,
+    icon="fa-hourglass-half",
+    label="delay, wait, pause, sleep, timer",
+    description=(
+        "Waits for the configured number of milliseconds, then forwards the "
+        "input data unchanged to the output."
+    ),
+)
+class Delay(Block):
+    delay_ms: Annotated[
+        int,
+        Config(),
+        Metadata(description="Delay duration in milliseconds before forwarding the input"),
+    ] = 1000
+
+    output: Output[Any]
+
+    @step()
+    async def delay(self, data: Any):
+        await asyncio.sleep(self.delay_ms / 1000)
+        self.output.send(data)

--- a/smartspace/blocks/google_search.py
+++ b/smartspace/blocks/google_search.py
@@ -89,13 +89,14 @@ class GoogleSearchResponse(BaseModel):
 
 # Block implementation that uses the Pydantic models
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.WEB,
     description="""
-    A block that connects to the Google Custom Search API, parses the JSON response 
+    A block that connects to the Google Custom Search API, parses the JSON response
     into a Pydantic model, and returns the structured result.
     It uses a configuration value 'page' (default=1) to determine which page of results to fetch.
     """,
     icon="fa-search",
+    label="google search, web search, custom search api, search engine, query web",
 )
 class GoogleSearch(Block):
     google_api_key: Annotated[str, Config()]

--- a/smartspace/blocks/http/http_1_0_0.py
+++ b/smartspace/blocks/http/http_1_0_0.py
@@ -47,7 +47,7 @@ class HTTPError(Exception):
 
 @metadata(
     description="Performs HTTP requests such as GET, POST, PUT, DELETE, and more.",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.WEB,
     icon="fa-cloud-download-alt",
     label="HTTP request, web API call, REST client, API request, web service call",
 )

--- a/smartspace/blocks/http/http_2_0_0.py
+++ b/smartspace/blocks/http/http_2_0_0.py
@@ -25,7 +25,7 @@ class ResponseObject(BaseModel):
 
 @metadata(
     description="Performs HTTP requests such as GET, POST, PUT, DELETE, and more.",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.WEB,
     icon="fa-cloud-download-alt",
     label="HTTP request, web API call, REST client, API request, web service call",
 )

--- a/smartspace/blocks/json_blocks.py
+++ b/smartspace/blocks/json_blocks.py
@@ -22,7 +22,7 @@ from smartspace.enums import BlockCategory
 
 @metadata(
     description="This block takes a JSON string or a list of JSON strings and parses them",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     icon="fa-code",
     label="parse JSON, convert JSON string, decode JSON, JSON deserialize, extract JSON data",
 )
@@ -47,7 +47,7 @@ class ParseJson(OperatorBlock):
 
 @metadata(
     description="This block removes a specified key from a JSON object. If 'recursive' is set to true, it recursively removes the key from all nested dictionaries; otherwise, it only removes the key from the top level. Returns a copy of the object with the key removed.",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     icon="fa-code",
     label="Remove Key from any json object",
 )
@@ -80,7 +80,7 @@ class RemoveProperty(OperatorBlock):
 
 @metadata(
     description="This block retrieves the keys of a JSON object (dictionary). Returns a list of keys.",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     icon="fa-code",
     label="Get Keys from json object",
 )
@@ -96,7 +96,7 @@ class GetKeys(OperatorBlock):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Uses JSONPath to extract data from a JSON object or list. This block will be moved to connection configuration in a future version",
     obsolete=True,
     label="extract JSON field, get JSON value, access JSON data, retrieve JSON property, JSON path query",
@@ -120,7 +120,7 @@ class GetJsonField(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Uses JSONPath to extract data from a JSON object or list.\nJSONPath implementation is from https://pypi.org/project/jsonpath-ng/.",
     icon="fa-search",
     label="get JSON path, query JSON data, extract JSON values, JSON lookup, search JSON",
@@ -148,7 +148,7 @@ class JoinType(Enum):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="""
 The `Join` block performs advanced join operations between two lists of dictionaries based on a specified key. It merges the data according to the selected join type, similar to SQL join operations, allowing for flexible data integration and transformation.
 
@@ -256,7 +256,7 @@ class Join(Block):
 
 @metadata(
     description="Merges multiple dictionaries into a single object. Accepts only dicts and combines all key-value pairs into one dictionary.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-cube",
     label="merge objects, combine dictionaries, build object, aggregate key-value pairs",
 )
@@ -271,7 +271,7 @@ class MergeObjects(Block):
 
 @metadata(
     description="Takes in inputs and creates an object containing the inputs",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-cube",
     label="create object, build dictionary, construct object, make key-value map, generate object",
 )
@@ -282,7 +282,7 @@ class CreateObject(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     label="object builder, json merge, dictionary update, data aggregation, object construction",
     description="Merges objects using dictionary unpacking (similar to jq's merge). Each new object is merged with the existing accumulated object.",
 )
@@ -335,7 +335,7 @@ class BuildObject(Block):
 
 @metadata(
     description="Takes in an object and sends each key-value pair to the corresponding output",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-th-large",
     label="unpack object, extract object properties, decompose dictionary, spread object, distribute fields",
 )

--- a/smartspace/blocks/limit.py
+++ b/smartspace/blocks/limit.py
@@ -1,0 +1,35 @@
+from typing import Annotated, Any
+
+from smartspace.core import Block, Config, Metadata, Output, State, metadata, step
+from smartspace.enums import BlockCategory
+
+
+@metadata(
+    category=BlockCategory.CONTROL,
+    icon="fa-gauge-high",
+    label="limit, counter, threshold, gate, limiter",
+    description=(
+        "Routes incoming items based on a configurable count limit. "
+        "Emits to `under_limit` until the limit is reached; afterwards emits to `reached_limit`."
+    ),
+)
+class Limit(Block):
+    limit: Annotated[
+        int,
+        Config(),
+        Metadata(description="Maximum number of items to pass through under_limit"),
+    ] = 5
+
+    count: Annotated[int, State()] = 0
+
+    under_limit: Output[Any]
+    reached_limit: Output[Any]
+
+    @step()
+    async def route(self, item: Any):
+        self.count += 1
+
+        if self.count < self.limit:
+            self.under_limit.send(item)
+        else:
+            self.reached_limit.send(item)

--- a/smartspace/blocks/lists.py
+++ b/smartspace/blocks/lists.py
@@ -20,7 +20,8 @@ firstItemT = TypeVar("firstItemT")
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
+    description="Returns the number of items in the input list.",
     icon="fa-sort-numeric-up",
     label="count items, list length, item count, size of list, total elements",
 )
@@ -31,7 +32,7 @@ class Count(OperatorBlock):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Joins a list of strings using the configured separator and outputs the resulting string.",
     icon="fa-link",
     label="join strings, concatenate text, combine strings, merge text, connect strings",
@@ -45,7 +46,7 @@ class JoinStrings(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Splits a string using the configured separator and outputs a list of the substrings",
     icon="fa-cut",
     label="split string, divide text, break string, tokenize text, parse string",
@@ -65,7 +66,7 @@ class SplitString(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Slices a list or string using the configured start and end indexes.",
     icon="fa-cut",
     label="slice list, extract portion, get segment, subset sequence, partial list",
@@ -80,9 +81,10 @@ class Slice(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Gets the first item from a list",
     icon="fa-arrow-alt-circle-left",
+    label="first, head, take one, list head, pop front",
 )
 class First(OperatorBlock, Generic[firstItemT]):
     @step(output_name="item")
@@ -91,7 +93,7 @@ class First(OperatorBlock, Generic[firstItemT]):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Flattens a list of lists into a single list",
     icon="fa-compress",
     label="flatten list, merge nested lists, combine nested arrays, unnest lists, simplify nested lists",
@@ -104,7 +106,7 @@ class Flatten(OperatorBlock):
 
 @metadata(
     description="Takes in inputs and creates a list containing the inputs.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-list-ul",
     label="create list, build list, construct list, form list, make list",
 )
@@ -115,7 +117,7 @@ class CreateList(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Appends an item to a list and outputs the updated list. Maintains the list state across calls.",
     label="list builder, dynamic list, item aggregation, list accumulation, append to list",
 )
@@ -129,7 +131,7 @@ class BuildList(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Merges objects from two lists by matching on the configured key.",
     obsolete=True,
     label="merge JSON lists, combine JSON arrays, join JSON objects, match and merge, consolidate JSON data",
@@ -163,7 +165,7 @@ class MergeLists(Block):
 
 @metadata(
     description="Takes in a list and sends each item to the corresponding output",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-th-list",
     label="unpack list, distribute items, extract list elements, spread array, decompose list",
 )
@@ -179,7 +181,7 @@ class UnpackList(Block):
 
 @metadata(
     description="Appends item to items and output resulting list",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-plus",
     label="append item, add item, extend list, insert item, concatenate item",
 )

--- a/smartspace/blocks/loops.py
+++ b/smartspace/blocks/loops.py
@@ -20,7 +20,7 @@ ItemT = TypeVar("ItemT")
 ResultT = TypeVar("ResultT")
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description="Loops through each item in the items input and sends them to the configured tool. Once all items have been processed, outputs the resulting list",
     icon="fa-project-diagram",
     label="map function, transform items, process list, iterate collection, apply function to list",
@@ -92,7 +92,7 @@ class Map(Block, Generic[ItemT, ResultT]):
             )
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description="Collects data from a channel and outputs them as a list once the channel closes.",
     icon="fa-boxes",
     label="collect list, gather items, accumulate data, assemble collection, aggregate entries",
@@ -125,7 +125,7 @@ class Collect(OperatorBlock, Generic[ItemT]):
             self.items.send(self.items_state)
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description="Loops through a list of items and outputs them one at a time",
     icon="fa-ellipsis-h\t",
     label="for each, iterate items, loop through list, process each item, step through collection",

--- a/smartspace/blocks/regex_match.py
+++ b/smartspace/blocks/regex_match.py
@@ -6,7 +6,7 @@ from smartspace.enums import BlockCategory
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Regex match or replace: if substitution string is empty, return list of matches; otherwise return replaced string.",
     icon="fa-text-width",
     label="regex match, regex replace, find and replace, pattern substitution, text extraction",

--- a/smartspace/blocks/sql.py
+++ b/smartspace/blocks/sql.py
@@ -7,7 +7,7 @@ from smartspace.core import Block, Config, metadata, step
 from smartspace.enums import BlockCategory
 
 @metadata(
-    category=BlockCategory.DATA,
+    category=BlockCategory.WEB,
     description=(
         "Executes an async SQL query via SQLAlchemy against any supported database. "
         "Ensure your `connection_string` uses the correct dialect+driver prefix and proper URL encoding. Examples:\n"
@@ -18,6 +18,7 @@ from smartspace.enums import BlockCategory
         "Percent-encode special characters in credentials (e.g., `^` → `%5E`)."
     ),
     icon="fa-database",
+    label="sql query, database, sqlalchemy, select, async db, relational",
 )
 class SQL(Block):
     connection_string: Annotated[str, Config()]

--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -11,7 +11,7 @@ from smartspace.enums import BlockCategory
 
 @metadata(
     description="Takes in a Jinja template string and renders it with the given inputs",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-file-alt",
     label="string template, text formatting, variable substitution, format string, template interpolation",
 )

--- a/smartspace/blocks/strings.py
+++ b/smartspace/blocks/strings.py
@@ -11,7 +11,7 @@ SequenceT = TypeVar("SequenceT", bound=str | list[Any])
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Concatenates 2 lists or strings",
     icon="fa-plus",
     label="concatenate strings, join strings, merge lists, combine text, append strings",

--- a/smartspace/blocks/template_object.py
+++ b/smartspace/blocks/template_object.py
@@ -6,7 +6,7 @@ from smartspace.enums import BlockCategory, InputDisplayType
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="""
     A block that takes a Jinja2 template string, fills the template,
     and then parses the result into a JSON object.

--- a/smartspace/blocks/time_block.py
+++ b/smartspace/blocks/time_block.py
@@ -35,7 +35,7 @@ class DateTimeRequest(BaseModel):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description=(
         "Provides comprehensive date and time operations including current time awareness, "
         "date arithmetic, formatting, parsing, timezone conversions, and component extraction. "

--- a/smartspace/blocks/transform.py
+++ b/smartspace/blocks/transform.py
@@ -1,0 +1,52 @@
+from typing import Annotated, Any
+
+import jmespath
+from jmespath.exceptions import JMESPathError
+
+from smartspace.core import Block, BlockError, Config, Metadata, Output, metadata, step
+from smartspace.enums import BlockCategory
+
+
+@metadata(
+    category=BlockCategory.TRANSFORM,
+    icon="fa-shuffle",
+    label="transform, jmespath, reshape, project, map, select, filter, json query, dynamic inputs, multi input",
+    description=(
+        "Transforms, filters, and reshapes JSON data using a JMESPath expression. "
+        "Accepts dynamic inputs: each connected input pin becomes a top-level key "
+        "in the document the expression sees. Example: with pins `user` and `items` "
+        "wired in, the expression `{name: user.name, count: length(items)}` returns "
+        "`{\"name\": ..., \"count\": ...}`. Unlike the JSONPath-based Get block, "
+        "JMESPath can construct new objects, apply filters (`[?type=='admin']`), "
+        "slice, pipe, and call built-in functions."
+    ),
+)
+class Transform(Block):
+    expression: Annotated[
+        str,
+        Config(),
+        Metadata(
+            description=(
+                "JMESPath expression to evaluate against an object whose keys are "
+                "the names of the connected input pins. See https://jmespath.org/ for syntax."
+            )
+        ),
+    ] = "@"
+
+    result: Output[Any]
+
+    @step()
+    async def transform(self, **inputs: Any):
+        try:
+            compiled = jmespath.compile(self.expression)
+        except JMESPathError as e:
+            raise BlockError(f"Invalid JMESPath expression {self.expression!r}: {e}")
+
+        try:
+            value = compiled.search(inputs)
+        except JMESPathError as e:
+            raise BlockError(
+                f"JMESPath evaluation failed for expression {self.expression!r}: {e}"
+            )
+
+        self.result.send(value)

--- a/smartspace/blocks/truncate_string.py
+++ b/smartspace/blocks/truncate_string.py
@@ -7,7 +7,7 @@ from smartspace.enums import BlockCategory
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="takes in a string input and truncates it given a token limit",
     icon="fa-cut",
     label="truncate string, shorten text, cut text, limit tokens, trim text",

--- a/smartspace/blocks/type_switch.py
+++ b/smartspace/blocks/type_switch.py
@@ -21,7 +21,7 @@ class TypeSwitchOption(Generic[ItemT]):
 
 @metadata(
     description="Checks the output schemas of the options and sends the input to the first option that matches",
-    category=BlockCategory.MISC,
+    category=BlockCategory.CONTROL,
     icon="fa-random",
     label="type switch, schema routing, type routing, data branching, conditional path",
 )

--- a/smartspace/blocks/variable.py
+++ b/smartspace/blocks/variable.py
@@ -11,7 +11,7 @@ from smartspace.enums import BlockCategory
   - **`set`**: Stores a new value.
   - **`get`**: Sends the current value out the output.
   - **`setGet`**: Combines setting and sending in a single action, immediately outputting the new value that is set""",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     label="variable storage, data holding, value storage, state management, data persistence",
 )
 class Variable(Block):

--- a/smartspace/blocks/website_scraper.py
+++ b/smartspace/blocks/website_scraper.py
@@ -18,7 +18,7 @@ class WebsiteDetails(BaseModel):
 
 @metadata(
     description="Scrapes the content of a website. Returns both the raw content and the content with metadata.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.WEB,
     icon="fa-globe",
     label="website scraper, web crawler, content extractor, web harvester, site parser",
 )

--- a/smartspace/enums.py
+++ b/smartspace/enums.py
@@ -2,9 +2,32 @@ from enum import Enum
 
 
 class BlockCategory(Enum):
-    AGENT = {"name": "Agent", "description": "An entity that performs actions"}
+    # --- Active taxonomy ---
+    AGENT = {
+        "name": "Agent",
+        "description": "LLM-driven, non-deterministic blocks",
+    }
+    DATA = {
+        "name": "Data",
+        "description": "Read, write, or search internal datasets, files, and embeddings",
+    }
+    WEB = {
+        "name": "Web",
+        "description": "Calls an external service over the network",
+    }
+    TRANSFORM = {
+        "name": "Transform",
+        "description": "Pure compute — reshape, parse, format, or convert data",
+    }
+    CONTROL = {
+        "name": "Control",
+        "description": "Routing, branching, looping, gating, and timing",
+    }
+
+    # --- Deprecated; kept for back-compat until all @metadata calls migrate ---
+    # Remove these in a follow-up PR once both the SDK's own blocks and
+    # downstream consumers (ai-api, etc.) have moved off them.
     FUNCTION = {"name": "Function", "description": "A callable entity"}
-    DATA = {"name": "Data", "description": "A data entity"}
     CUSTOM = {"name": "Custom", "description": "A custom entity"}
     MISC = {"name": "Misc", "description": "Doesnt belong to any category"}
 


### PR DESCRIPTION
## What & why

Two coordinated changes for the block system:

### 1 · New blocks — `Delay`, `Limit`, `Transform`

Three blocks previously living in `Smartspace-ai-api/app/blocks/native/` had **zero `app.*` dependencies** and belong here in the SDK alongside the other generic utilities.

- **`Delay`** (CONTROL) — async-sleep then forward input.
- **`Limit`** (CONTROL) — counter-based routing: emits to `under_limit` until a threshold, then `reached_limit`.
- **`Transform`** (TRANSFORM) — renamed from native `Project`. JMESPath expression block with **dynamic inputs** (each connected pin becomes a top-level key in the JMESPath document — same pattern as `StringTemplate`). The rename is in-place because the original `Project` block was only on `develop` + an open feature branch, never released.

### 2 · Category taxonomy — `AGENT / FUNCTION / DATA / CUSTOM / MISC` → `AGENT / DATA / WEB / TRANSFORM / CONTROL`

The current 5-category set has three problems:
- `FUNCTION` describes everything ("a callable entity") and ends up holding ~half the SDK blocks.
- `MISC` is a junk drawer.
- `CUSTOM` has 1 block (`MarkdownToRTF`) with no clear meaning.
- No category captures "external service call" so HTTP / GoogleSearch / SQL are scattered across `FUNCTION` and `DATA`.

New set:

| Category | What lives here |
|---|---|
| **AGENT** | LLM-driven, non-deterministic (none in SDK; lives in `Smartspace-ai-api`) |
| **DATA** | Read / write / search internal datasets, files, embeddings (none in SDK) |
| **WEB** | Calls an external service over the network (`HTTPRequest` ×2, `GoogleSearch`, `SQL`, `WebsiteScraper`) |
| **TRANSFORM** | Pure compute — reshape, parse, format, convert (most of the SDK) |
| **CONTROL** | Routing, branching, looping, gating, timing (`If`, `Switch`, `Filter`, `Map`, `ForEach`, `Collect`, `TypeSwitch`, `Delay`, `Limit`) |

`CONTROL` (not `FLOW`) avoids collision with the user-facing "flow" concept.

**This PR is additive** — it adds `WEB`, `TRANSFORM`, `CONTROL` to `BlockCategory` and **keeps** `FUNCTION` / `CUSTOM` / `MISC` for back-compat. They're tagged in the enum docstring as deprecated and should be removed in a follow-up PR **after** `Smartspace-ai-api` and any other downstream consumers have migrated. Removing them now would crash every `@metadata(category=BlockCategory.FUNCTION)` call downstream at module-import time.

### 3 · Label / description gaps

Audit surfaced four blocks with missing metadata fields:

- `GoogleSearch`, `First`, `SQL` — missing `label=`.
- `Count` — missing `description=`.

All four filled in.

## Test plan
- [x] All SDK block modules import cleanly (verified locally).
- [ ] Run the SDK's existing test suite.
- [ ] Smoke-test in a `Smartspace-ai-api` checkout: bump the SDK rev in `pyproject.toml`, confirm `BlockFactory.native_blocks()` still loads without errors. The deprecated `FUNCTION` / `CUSTOM` / `MISC` enum members must still resolve so existing downstream `@metadata` calls keep working.
- [ ] In the UI block picker, verify the new `WEB`, `TRANSFORM`, `CONTROL` categories render correctly with their descriptions.
- [ ] Verify the three new blocks (`Delay`, `Limit`, `Transform`) appear in their expected categories.

## Risk & rollback

- **Low risk overall.** The taxonomy change is additive — old `BlockCategory.FUNCTION` etc. still resolve, so the SDK is fully back-compatible with current downstream code.
- The three new blocks shadow native versions in `Smartspace-ai-api` by logical name (`Delay`, `Limit`, `Transform`). Downstream loads native after SDK in `app/blocks/__init__.py`, so the native versions currently win on registry collision; the downstream PR ([Smartspace-ai-api#679](https://github.com/Smartspace-ai/Smartspace-ai-api/pull/679)) deletes the native files in a follow-up commit once this lands and the rev bumps.
- Rollback: revert the commit. Nothing here is destructive.

## Follow-ups (separate PRs)

1. **Downstream rev bump + native cleanup** — `Smartspace-ai-api` PR #679 (already open) bumps the SDK rev, deletes the now-redundant native `Delay` / `Limit` / `Transform` files, and runs a sweep script to migrate downstream `@metadata(category=…)` calls to the new taxonomy.
2. **Remove deprecated enum members** — once #1 ships, a small SDK PR removes `FUNCTION` / `CUSTOM` / `MISC` from `BlockCategory`.

## Linked work

- Downstream PR: https://github.com/Smartspace-ai/Smartspace-ai-api/pull/679
- Design / staging artifacts: `Smartspace-ai-api/.claude/designs/sdk-migration/`