### PR TITLE
fix(release-pr): tolerate CRLF line endings when parsing pyproject version

### DIFF
--- a/.github/workflows/open-standing-release-pr.yml
+++ b/.github/workflows/open-standing-release-pr.yml
@@ -66,7 +66,8 @@ jobs:
 
           extract_version() {
             # Reads `version = "X.Y.Z"` from a pyproject.toml on stdin.
-            sed -n 's/^version = "\(.*\)"$/\1/p' | head -1
+            # Tolerant of CRLF line endings — the repo's pyproject.toml is CRLF.
+            sed -n 's/^version = "\([^"]*\)".*$/\1/p' | head -1 | tr -d '\r'
           }
 
           MAIN_VERSION=$(git show origin/main:pyproject.toml | extract_version)


### PR DESCRIPTION
## Summary
Fixes the `Open standing release PR` workflow that failed on the first run after #272 merged.

## Root cause
`pyproject.toml` is stored with CRLF line endings. My sed regex `s/^version = "\(.*\)"$/\1/p` anchors `$` before the `\r`, so the trailing `"` doesn't match and the captured group comes back empty — workflow errors with `Could not parse version from pyproject.toml (main= dev=)`.

## Fix
- Match `[^"]*` between the quotes and accept any trailing characters (`.*$`) so the `\r` doesn't break the regex.
- Pipe through `tr -d '\r'` as a belt-and-braces strip in case anything else leaks in.

```diff
- sed -n 's/^version = "\(.*\)"$/\1/p' | head -1
+ sed -n 's/^version = "\([^"]*\)".*$/\1/p' | head -1 | tr -d '\r'
```

## Test plan
- [ ] Merge → workflow fires on the resulting push to develop and reads `main=0.1.11 dev=0.1.11 main_next=0.1.12 -> next=0.1.12`
- [ ] `release/next` branch is created and the standing PR opens against `main`