### PR TITLE
chore(blocks): add CONTROL category to User block

### DIFF
--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -2441,6 +2441,12 @@ def callback() -> Callable[[Callable[Concatenate[B, P], Awaitable]], Callback[B,
 UserMessageT = TypeVar("UserMessageT")
 
 
+@metadata(
+    category=BlockCategory.CONTROL,
+    icon="fa-user",
+    label="user input, user form, ask user, human in the loop, user response",
+    description="Sends a message to the user and waits for a response. The response schema determines the form fields shown.",
+)
 class User(WorkSpaceBlock, Generic[UserMessageT]):
     schema: GenericSchema[UserMessageT] = GenericSchema({"type": "string"})
     response: Output[UserMessageT]


### PR DESCRIPTION
## What & why
- `User` had no `@metadata` decorator → UI showed it under miscellaneous
- It's a control-flow block (pauses flow, waits for human response), so `CONTROL` is correct
- Also adds icon, label, and description for discoverability

## Test plan
- [ ] Block picker shows `User` under the Control category
- [ ] Existing flows using User block unaffected

## Risk & rollback
- Metadata-only change; no runtime behaviour affected
- Rollback: revert this commit

## Linked work
- Follow-up to `Smartspace-ai/Smartspace-ai-api` block category sweep