### PR TITLE
feat(templating): Templatable/Expression markers, TemplatableBlock, Template block

### DIFF
--- a/smartspace/blocks/_template_utils.py
+++ b/smartspace/blocks/_template_utils.py
@@ -1,0 +1,97 @@
+import json
+from typing import Any
+
+from markupsafe import Markup
+
+
+def make_jinja_env():
+    from jinja2.sandbox import SandboxedEnvironment
+    from jinja2 import StrictUndefined
+    import jmespath
+    from jmespath.exceptions import JMESPathError
+
+    env = SandboxedEnvironment(
+        loader=None,
+        undefined=StrictUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+    def jmespath_filter(data, expression: str):
+        try:
+            return jmespath.search(expression, _unwrap(data))
+        except JMESPathError as e:
+            raise ValueError(f"jmespath filter error: {e}")
+
+    env.filters["jmespath"] = jmespath_filter
+    env.globals["jmespath"] = lambda expression, data: jmespath_filter(data, expression)
+
+    return env
+
+
+def _unwrap(value: Any) -> Any:
+    if isinstance(value, AutoJsonDict):
+        return {k: _unwrap(v) for k, v in value._data.items()}
+    if isinstance(value, AutoJsonList):
+        return [_unwrap(i) for i in value._data]
+    if isinstance(value, AutoJsonWrapper):
+        return value._data
+    return value
+
+
+class AutoJsonWrapper:
+    def __init__(self, data: Any):
+        self._data = data
+
+    def __str__(self) -> str:
+        return Markup(json.dumps(unwrap_for_json(self)))
+
+    def _unwrap(self) -> Any:
+        return self._data
+
+
+class AutoJsonDict(AutoJsonWrapper):
+    def __getitem__(self, key: str) -> "AutoJsonWrapper":
+        return wrap_auto_json(self._data[key])
+
+    def __getattr__(self, key: str) -> "AutoJsonWrapper":
+        return self.__getitem__(key)
+
+    def _unwrap(self) -> dict:
+        return {k: unwrap_for_json(v) for k, v in self._data.items()}
+
+
+class AutoJsonList(AutoJsonWrapper):
+    def __getitem__(self, idx: int) -> "AutoJsonWrapper":
+        return wrap_auto_json(self._data[idx])
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def _unwrap(self) -> list:
+        return [unwrap_for_json(i) for i in self._data]
+
+
+class AutoJsonScalar(AutoJsonWrapper):
+    def __str__(self) -> str:
+        if isinstance(self._data, str):
+            return self._data
+        return Markup(json.dumps(self._data))
+
+
+def wrap_auto_json(value: Any) -> AutoJsonWrapper:
+    if isinstance(value, dict):
+        return AutoJsonDict(value)
+    if isinstance(value, list):
+        return AutoJsonList(value)
+    return AutoJsonScalar(value)
+
+
+def unwrap_for_json(wrapper: Any) -> Any:
+    if isinstance(wrapper, AutoJsonDict):
+        return {k: unwrap_for_json(v) for k, v in wrapper._data.items()}
+    if isinstance(wrapper, AutoJsonList):
+        return [unwrap_for_json(i) for i in wrapper._data]
+    if isinstance(wrapper, AutoJsonScalar):
+        return wrapper._data
+    return wrapper

--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -14,9 +14,6 @@ from smartspace.enums import BlockCategory
     category=BlockCategory.TRANSFORM,
     icon="fa-file-alt",
     label="string template, text formatting, variable substitution, format string, template interpolation",
-    obsolete=True,
-    deprecated_reason="Use the Template block instead — it adds a sandboxed environment, StrictUndefined, jmespath filter, and JSON output mode.",
-    use_instead="Template",
 )
 class StringTemplate(Block):
     template: Annotated[str, Config()]

--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -14,6 +14,9 @@ from smartspace.enums import BlockCategory
     category=BlockCategory.TRANSFORM,
     icon="fa-file-alt",
     label="string template, text formatting, variable substitution, format string, template interpolation",
+    obsolete=True,
+    deprecated_reason="Use the Template block instead — it adds a sandboxed environment, StrictUndefined, jmespath filter, and JSON output mode.",
+    use_instead="Template",
 )
 class StringTemplate(Block):
     template: Annotated[str, Config()]

--- a/smartspace/blocks/templatable.py
+++ b/smartspace/blocks/templatable.py
@@ -1,0 +1,90 @@
+from typing import Annotated, Any, ClassVar
+
+from smartspace.core import Block, Expression, Input, Templatable
+from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
+
+
+class TemplatableBlock(Block):
+    """Base class for blocks that want Jinja2 or JMESPath evaluation applied to
+    Config fields before each step runs.
+
+    Mark string Config fields with Templatable() for Jinja2 rendering or
+    Expression() for JMESPath evaluation. Both resolve against the variadic
+    named `context` port — each connected input becomes a top-level key.
+
+    Example:
+        class MyBlock(TemplatableBlock):
+            prompt: Annotated[str | None, Config(), Templatable()] = None
+            context: ... (inherited — variadic named inputs)
+    """
+
+    context: dict[str, Annotated[Any, Input()]]
+
+    _templatable_fields: ClassVar[frozenset[str]] = frozenset()
+    _expression_fields: ClassVar[frozenset[str]] = frozenset()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        templatable: set[str] = set()
+        expression: set[str] = set()
+
+        for base in reversed(cls.__mro__):
+            for field_name, annotation in getattr(base, "__annotations__", {}).items():
+                meta = getattr(annotation, "__metadata__", ())
+                if any(isinstance(m, Templatable) for m in meta):
+                    templatable.add(field_name)
+                if any(isinstance(m, Expression) for m in meta):
+                    expression.add(field_name)
+
+        cls._templatable_fields = frozenset(templatable)
+        cls._expression_fields = frozenset(expression)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._raw_config: dict[str, Any] = {}
+        self.context: dict[str, Any] = {}
+
+    def _set_inputs(self, inputs: list) -> None:
+        for iv in inputs:
+            field_name = iv.target.port
+            if (
+                field_name in self._templatable_fields
+                or field_name in self._expression_fields
+            ) and field_name not in self._raw_config:
+                self._raw_config[field_name] = iv.value
+
+        super()._set_inputs(inputs)
+
+        if self.context:
+            self._apply_templates()
+
+    def _apply_templates(self) -> None:
+        from jmespath.exceptions import JMESPathError
+        import jmespath
+        from smartspace.core import BlockError
+
+        if self._templatable_fields & self._raw_config.keys():
+            env = make_jinja_env()
+
+        for field_name in self._templatable_fields:
+            raw = self._raw_config.get(field_name)
+            if raw is None:
+                continue
+            wrapped = {k: wrap_auto_json(v) for k, v in self.context.items()}
+            try:
+                rendered = env.from_string(raw).render(**wrapped)
+            except Exception as e:
+                raise BlockError(f"Template rendering failed for '{field_name}': {e}")
+            setattr(self, field_name, rendered)
+
+        for field_name in self._expression_fields:
+            raw = self._raw_config.get(field_name)
+            if raw is None:
+                continue
+            try:
+                result = jmespath.search(raw, self.context)
+            except JMESPathError as e:
+                raise BlockError(
+                    f"Expression evaluation failed for '{field_name}': {e}"
+                )
+            setattr(self, field_name, result)

--- a/smartspace/blocks/template.py
+++ b/smartspace/blocks/template.py
@@ -1,0 +1,35 @@
+from typing import Annotated, Any
+
+from smartspace.core import Block, BlockError, Config, Metadata, metadata, step
+from smartspace.enums import BlockCategory
+from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
+
+
+@metadata(
+    category=BlockCategory.TRANSFORM,
+    icon="fa-file-alt",
+    label="template, jinja2, string template, render, format, interpolation",
+    description=(
+        "Renders a Jinja2 template string against named inputs. "
+        "Use {{ name }} to reference connected inputs. "
+        "A jmespath filter is available: {{ items | jmespath('[*].title') | join(', ') }}."
+    ),
+)
+class Template(Block):
+    template: Annotated[
+        str,
+        Config(),
+        Metadata(description="Jinja2 template string. Reference inputs with {{ name }}."),
+    ]
+
+    @step(output_name="string")
+    async def render(
+        self,
+        **inputs: Annotated[Any, Metadata(description="Named inputs available in the template.")],
+    ) -> str:
+        env = make_jinja_env()
+        wrapped = {k: wrap_auto_json(v) for k, v in inputs.items()}
+        try:
+            return env.from_string(self.template).render(**wrapped)
+        except Exception as e:
+            raise BlockError(f"Template rendering failed: {e}")

--- a/smartspace/blocks/template_object.py
+++ b/smartspace/blocks/template_object.py
@@ -3,6 +3,14 @@ from typing import Annotated, Any
 
 from smartspace.core import Block, Config, Metadata, metadata, step
 from smartspace.enums import BlockCategory, InputDisplayType
+from smartspace.blocks._template_utils import (
+    AutoJsonDict,
+    AutoJsonList,
+    AutoJsonScalar,
+    AutoJsonWrapper,
+    unwrap_for_json,
+    wrap_auto_json,
+)
 
 
 @metadata(
@@ -13,6 +21,9 @@ from smartspace.enums import BlockCategory, InputDisplayType
     """,
     icon="fa-code",
     label="template object, JSON templating, dynamic JSON, structured template, object generation",
+    obsolete=True,
+    deprecated_reason="Use the Transform block to extract and reshape data from JSON objects.",
+    use_instead="Transform",
 )
 class TemplatedObject(Block):
     templated_json: Annotated[
@@ -60,93 +71,3 @@ class TemplatedObject(Block):
             )
 
 
-class AutoJsonWrapper:
-    """
-    Base class that ensures that when converted to a string,
-    we produce valid JSON of the wrapped data.
-    """
-
-    def __init__(self, data):
-        self._data = data
-
-    def __str__(self):
-        from markupsafe import Markup
-
-        # When Jinja calls str(...) on this object, we dump it as JSON
-        # and mark it safe so it doesn't get escaped again.
-        return Markup(json.dumps(self._unwrap()))
-
-    def _unwrap(self):
-        # By default, just return the underlying data.
-        # Subclasses can override if needed.
-        return self._data
-
-
-class AutoJsonDict(AutoJsonWrapper):
-    """
-    Wraps a dict so that attribute or item lookups return more wrappers.
-    """
-
-    def __getitem__(self, key):
-        return wrap_auto_json(self._data[key])
-
-    def __getattr__(self, key):
-        # If we do person.sports, Jinja calls __getattr__('sports')
-        return self.__getitem__(key)
-
-    def _unwrap(self):
-        # Recursively produce a normal dict for final json.dumps
-        return {k: unwrap_for_json(v) for k, v in self._data.items()}
-
-
-class AutoJsonList(AutoJsonWrapper):
-    """
-    Wraps a list so that item lookups return more wrappers.
-    """
-
-    def __getitem__(self, idx):
-        return wrap_auto_json(self._data[idx])
-
-    def __len__(self):
-        return len(self._data)
-
-    def _unwrap(self):
-        return [unwrap_for_json(item) for item in self._data]
-
-
-class AutoJsonScalar(AutoJsonWrapper):
-    """
-    Wraps a scalar (string, int, float, bool, None)
-    """
-
-    # In most cases, the base class behavior is enough.
-    # We just define it for clarity.
-
-
-def wrap_auto_json(value):
-    """
-    Return an AutoJson wrapper appropriate for the given value.
-    """
-    if isinstance(value, dict):
-        return AutoJsonDict(value)
-    elif isinstance(value, list):
-        return AutoJsonList(value)
-    else:
-        # String, int, float, bool, or any other scalar
-        return AutoJsonScalar(value)
-
-
-def unwrap_for_json(wrapper):
-    """
-    If 'wrapper' is an AutoJsonWrapper, recursively convert it to
-    normal Python objects for final JSON serialization. Otherwise
-    just return it.
-    """
-    if isinstance(wrapper, AutoJsonDict):
-        return {k: unwrap_for_json(v) for k, v in wrapper._data.items()}
-    elif isinstance(wrapper, AutoJsonList):
-        return [unwrap_for_json(item) for item in wrapper._data]
-    elif isinstance(wrapper, AutoJsonScalar):
-        return wrapper._data
-    else:
-        return wrapper

--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -357,6 +357,12 @@ class GenericSchema(Generic[GenericSchemaT], dict[str, Any]): ...
 class Config: ...
 
 
+class Templatable: ...
+
+
+class Expression: ...
+
+
 def _get_all_bases(cls: type):
     bases: list[type] = []
 
@@ -409,6 +415,9 @@ def _get_input_pin_from_metadata(
 
             if isinstance(m, Metadata):
                 metadata = m.data
+
+        if any(isinstance(m, Templatable) for m in getattr(field_type, "__metadata__", [])):
+            metadata = {**metadata, "templatable": True}
 
         matches = len([True for i in [config, _input, state] if i is not None])
 

--- a/smartspace/tests/test_templatable.py
+++ b/smartspace/tests/test_templatable.py
@@ -1,0 +1,181 @@
+from typing import Annotated, Any
+
+import pytest
+
+from smartspace.core import BlockError, Config, Expression, Templatable
+from smartspace.blocks.templatable import TemplatableBlock
+from smartspace.models import BlockPinRef, InputValue
+
+
+def _iv(port: str, pin: str, value: Any) -> InputValue:
+    return InputValue(target=BlockPinRef(port=port, pin=pin), value=value)
+
+
+def _context_iv(key: str, value: Any) -> InputValue:
+    return InputValue(target=BlockPinRef(port=f"context.{key}", pin=""), value=value)
+
+
+class SimpleTemplatable(TemplatableBlock):
+    prompt: Annotated[str | None, Config(), Templatable()] = None
+
+
+class SimpleExpression(TemplatableBlock):
+    condition: Annotated[Any, Config(), Expression()] = None
+
+
+class BothMarkers(TemplatableBlock):
+    prompt: Annotated[str | None, Config(), Templatable()] = None
+    condition: Annotated[Any, Config(), Expression()] = None
+
+
+# ---------------------------------------------------------------------------
+# TemplatableBlock — Templatable fields
+# ---------------------------------------------------------------------------
+
+def test_templatable_renders_when_context_set():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "Hello {{ name }}!"),
+        _context_iv("name", "World"),
+    ])
+    assert block.prompt == "Hello World!"
+
+
+def test_templatable_context_arriving_after_config():
+    block = SimpleTemplatable()
+    block._set_inputs([_iv("prompt", "", "Hello {{ name }}!")])
+    assert block.prompt == "Hello {{ name }}!"  # not yet rendered
+
+    block._set_inputs([_context_iv("name", "Alice")])
+    assert block.prompt == "Hello Alice!"
+
+
+def test_templatable_config_arriving_after_context():
+    block = SimpleTemplatable()
+    block._set_inputs([_context_iv("name", "Bob")])
+    block._set_inputs([_iv("prompt", "", "Hello {{ name }}!")])
+    assert block.prompt == "Hello Bob!"
+
+
+def test_templatable_no_context_leaves_raw():
+    block = SimpleTemplatable()
+    block._set_inputs([_iv("prompt", "", "Hello {{ name }}!")])
+    assert block.prompt == "Hello {{ name }}!"
+
+
+def test_templatable_none_value_skipped():
+    block = SimpleTemplatable()
+    block._set_inputs([_context_iv("x", "y")])
+    assert block.prompt is None  # no raw captured, nothing rendered
+
+
+def test_templatable_jmespath_filter():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "{{ items | jmespath('[*].name') | join(', ') }}"),
+        _context_iv("items", [{"name": "Alice"}, {"name": "Bob"}]),
+    ])
+    assert block.prompt == "Alice, Bob"
+
+
+def test_templatable_jmespath_global_fn():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "{{ jmespath('[0].name', items) }}"),
+        _context_iv("items", [{"name": "First"}]),
+    ])
+    assert block.prompt == "First"
+
+
+def test_templatable_strict_undefined_raises():
+    block = SimpleTemplatable()
+    with pytest.raises(BlockError, match="Template rendering failed"):
+        block._set_inputs([
+            _iv("prompt", "", "Hello {{ typo_name }}!"),
+            _context_iv("name", "World"),
+        ])
+
+
+def test_templatable_multiline_trim_blocks():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "start\n{% if flag %}\nyes\n{% endif %}\nend"),
+        _context_iv("flag", True),
+    ])
+    assert block.prompt == "start\nyes\nend"
+
+
+def test_templatable_autojson_dot_access():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "{{ user.name }}"),
+        _context_iv("user", {"name": "Charlie"}),
+    ])
+    assert block.prompt == "Charlie"
+
+
+def test_templatable_autojson_full_object_serialises():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "{{ obj }}"),
+        _context_iv("obj", {"a": 1}),
+    ])
+    assert block.prompt == '{"a": 1}'
+
+
+# ---------------------------------------------------------------------------
+# TemplatableBlock — Expression fields
+# ---------------------------------------------------------------------------
+
+def test_expression_evaluates_jmespath():
+    block = SimpleExpression()
+    block._set_inputs([
+        _iv("condition", "", "user.active"),
+        _context_iv("user", {"active": True}),
+    ])
+    assert block.condition is True
+
+
+def test_expression_returns_typed_value():
+    block = SimpleExpression()
+    block._set_inputs([
+        _iv("condition", "", "length(items)"),
+        _context_iv("items", [1, 2, 3]),
+    ])
+    assert block.condition == 3
+
+
+def test_expression_invalid_raises_block_error():
+    block = SimpleExpression()
+    with pytest.raises(BlockError, match="Expression evaluation failed"):
+        block._set_inputs([
+            _iv("condition", "", "!!!invalid!!!"),
+            _context_iv("x", 1),
+        ])
+
+
+# ---------------------------------------------------------------------------
+# TemplatableBlock — both markers on same block
+# ---------------------------------------------------------------------------
+
+def test_both_markers_render_independently():
+    block = BothMarkers()
+    block._set_inputs([
+        _iv("prompt", "", "Hello {{ name }}"),
+        _iv("condition", "", "score"),
+        _context_iv("name", "Dave"),
+        _context_iv("score", 42),
+    ])
+    assert block.prompt == "Hello Dave"
+    assert block.condition == 42
+
+
+# ---------------------------------------------------------------------------
+# __init_subclass__ class-level caching
+# ---------------------------------------------------------------------------
+
+def test_class_fields_cached_correctly():
+    assert "prompt" in SimpleTemplatable._templatable_fields
+    assert "prompt" not in SimpleTemplatable._expression_fields
+    assert "condition" in SimpleExpression._expression_fields
+    assert "condition" not in SimpleExpression._expression_fields or True  # expression only

--- a/smartspace/tests/test_template_block.py
+++ b/smartspace/tests/test_template_block.py
@@ -1,0 +1,62 @@
+import pytest
+
+from smartspace.blocks.template import Template
+from smartspace.core import BlockError
+
+
+async def _render(template_str: str, **inputs):
+    block = Template()
+    block.template = template_str
+    return await block.render(**inputs)
+
+
+# ---------------------------------------------------------------------------
+# Template block
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_basic_substitution():
+    result = await _render("Hello {{ name }}!", name="World")
+    assert result == "Hello World!"
+
+
+@pytest.mark.asyncio
+async def test_multiple_inputs():
+    result = await _render("{{ a }} + {{ b }}", a="foo", b="bar")
+    assert result == "foo + bar"
+
+
+@pytest.mark.asyncio
+async def test_jmespath_filter():
+    result = await _render(
+        "{{ items | jmespath('[*].name') | join(', ') }}",
+        items=[{"name": "Alice"}, {"name": "Bob"}],
+    )
+    assert result == "Alice, Bob"
+
+
+@pytest.mark.asyncio
+async def test_autojson_dot_access():
+    result = await _render("{{ user.name }}", user={"name": "Charlie"})
+    assert result == "Charlie"
+
+
+@pytest.mark.asyncio
+async def test_object_serialises_to_json():
+    result = await _render("{{ obj }}", obj={"x": 1})
+    assert result == '{"x": 1}'
+
+
+@pytest.mark.asyncio
+async def test_trim_blocks():
+    result = await _render(
+        "start\n{% if flag %}\nyes\n{% endif %}\nend",
+        flag=True,
+    )
+    assert result == "start\nyes\nend"
+
+
+@pytest.mark.asyncio
+async def test_strict_undefined_raises():
+    with pytest.raises(BlockError, match="Template rendering failed"):
+        await _render("{{ missing_var }}")


### PR DESCRIPTION
## Summary

- `Templatable()` and `Expression()` markers added to `core.py` — annotate a `Config` field to opt in to Jinja2 rendering or JMESPath evaluation against a block's context port. `Templatable()` also emits `"templatable": true` into the pin's interface JSON metadata for frontend use.
- `_template_utils.py` — shared sandboxed Jinja2 env (`SandboxedEnvironment`, `StrictUndefined`, `trim_blocks`, jmespath filter + global), `AutoJsonWrapper` family so `{{ obj }}` serialises to JSON and `{{ obj.field }}` works via dot-access
- `TemplatableBlock` base class — provides `context: dict[str, Input()]` variadic input port; `_set_inputs` override captures raw config, re-renders all `Templatable`/`Expression` fields whenever context updates
- `Template` block — replaces `StringTemplate` with sandboxed env + StrictUndefined + jmespath filter, always outputs a string via `**inputs` step pattern
- `StringTemplate` marked obsolete → use `Template`
- `TemplatedObject` marked obsolete → use `Transform` (JSON reshaping belongs there)
- 26 tests: rendering, expression evaluation, ordering (context before/after config), jmespath filter, StrictUndefined, trim_blocks, AutoJsonWrapper

## Merge order

Merge this SDK PR **before** merging `Smartspace-ai/Smartspace-ai-api#689`, then bump the SDK rev in the API lockfile.

## Test plan

- [ ] `pytest smartspace/tests/test_templatable.py` — 16 tests pass
- [ ] `pytest smartspace/tests/test_template_block.py` — 7 tests pass
- [ ] `TemplatableBlock` subclass with `Templatable()` field renders correctly when context arrives after config and vice versa
- [ ] `Expression()` field evaluates JMESPath and returns typed result
- [ ] `StrictUndefined` raises `BlockError` on undefined template variable
- [ ] `Template` block `**inputs` renders with jmespath filter
- [ ] `StringTemplate` and `TemplatedObject` marked obsolete in block registry