### PR TITLE
feat(blocks): StringTemplate v2, obsolete stale templates, fix base class registration

### DIFF
--- a/.github/workflows/open-standing-release-pr.yml
+++ b/.github/workflows/open-standing-release-pr.yml
@@ -66,7 +66,8 @@ jobs:
 
           extract_version() {
             # Reads `version = "X.Y.Z"` from a pyproject.toml on stdin.
-            sed -n 's/^version = "\(.*\)"$/\1/p' | head -1
+            # Tolerant of CRLF line endings — the repo's pyproject.toml is CRLF.
+            sed -n 's/^version = "\([^"]*\)".*$/\1/p' | head -1 | tr -d '\r'
           }
 
           MAIN_VERSION=$(git show origin/main:pyproject.toml | extract_version)

--- a/.github/workflows/open-standing-release-pr.yml
+++ b/.github/workflows/open-standing-release-pr.yml
@@ -1,0 +1,145 @@
+# Maintains the standing `release/next → main` PR with an automatic patch
+# version bump on pyproject.toml. Merging the PR triggers release.yml to
+# publish that version to PyPI and tag `v<version>`.
+#
+# On every push to develop:
+#   1. Hard-resets `release/next` to develop's HEAD
+#   2. Computes next version = max(develop_version, main_version + patch)
+#      — so manual minor/major bumps on develop are respected; default is
+#      a patch bump from main.
+#   3. Runs `poetry version <next>` on release/next, commits the bump
+#   4. Force-pushes `release/next`
+#   5. Opens the standing PR if it doesn't already exist
+#
+# Releasing develop → main becomes "click Merge on the standing PR".
+# No human ever creates or checks out `release/next`.
+
+name: Open standing release PR
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: standing-release-pr
+  cancel-in-progress: true
+
+jobs:
+  update:
+    if: github.repository == 'Smartspace-ai/smartspace-sdk'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10.15"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.8.3
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Reset release/next to develop
+        run: |
+          git fetch origin main develop
+          git checkout -B release/next origin/develop
+
+      - name: Compute next version
+        id: ver
+        run: |
+          set -euo pipefail
+
+          extract_version() {
+            # Reads `version = "X.Y.Z"` from a pyproject.toml on stdin.
+            sed -n 's/^version = "\(.*\)"$/\1/p' | head -1
+          }
+
+          MAIN_VERSION=$(git show origin/main:pyproject.toml | extract_version)
+          DEV_VERSION=$(extract_version < pyproject.toml)
+
+          if [ -z "$MAIN_VERSION" ] || [ -z "$DEV_VERSION" ]; then
+            echo "::error::Could not parse version from pyproject.toml (main=$MAIN_VERSION dev=$DEV_VERSION)"
+            exit 1
+          fi
+
+          IFS='.' read -ra PARTS <<< "$MAIN_VERSION"
+          if [ "${#PARTS[@]}" -ne 3 ]; then
+            echo "::error::Unexpected version shape on main: $MAIN_VERSION"
+            exit 1
+          fi
+          MAIN_NEXT="${PARTS[0]}.${PARTS[1]}.$((PARTS[2]+1))"
+
+          NEXT=$(printf '%s\n%s\n' "$DEV_VERSION" "$MAIN_NEXT" | sort -V | tail -1)
+
+          echo "main=$MAIN_VERSION  dev=$DEV_VERSION  main_next=$MAIN_NEXT  -> next=$NEXT"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Apply version bump on release/next
+        run: |
+          poetry version "${{ steps.ver.outputs.next }}"
+          if git diff --quiet pyproject.toml; then
+            echo "pyproject.toml already at ${{ steps.ver.outputs.next }} — nothing to commit."
+          else
+            git add pyproject.toml
+            git commit -m "chore(release): bump version to ${{ steps.ver.outputs.next }}"
+          fi
+
+      # Force-push: release/next is fully derived from develop + version bump
+      # each run. Local commits to release/next are intentionally lost.
+      - name: Force-push release/next
+        run: git push origin release/next --force
+
+      - name: Ensure standing release PR exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          OPEN=$(gh pr list --head release/next --base main --state open --json number --jq 'length')
+          if [ "$OPEN" != "0" ]; then
+            NUM=$(gh pr list --head release/next --base main --state open --json number --jq '.[0].number')
+            echo "Standing release PR already open at #$NUM — force-push has updated it."
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head release/next \
+            --title "Release: develop → main (standing, v${{ steps.ver.outputs.next }})" \
+            --body-file - <<EOF
+          Standing release PR. Auto-updated on every push to \`develop\`.
+
+          **Merging this PR releases \`v${{ steps.ver.outputs.next }}\` to PyPI** (via [\`release.yml\`](.github/workflows/release.yml)) and creates the matching GitHub release/tag.
+
+          ## How this works
+
+          [\`open-standing-release-pr.yml\`](.github/workflows/open-standing-release-pr.yml) runs on every push to \`develop\`:
+
+          1. Resets \`release/next\` to develop's HEAD
+          2. Computes \`next = max(develop_version, main_version + patch)\`
+          3. Runs \`poetry version <next>\` and commits the bump
+          4. Force-pushes \`release/next\`
+
+          ## Bumping minor or major
+
+          Default is a patch bump from \`main\`. To release a minor or major version, bump \`pyproject.toml\` on \`develop\` manually (e.g. \`poetry version minor\`) and push — the workflow will respect any version higher than \`main + patch\`.
+
+          ## Don't commit to \`release/next\`
+
+          The branch is force-pushed by automation. Any local commits will be lost on the next sync.
+          EOF

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,52 @@
+# Gates merges into develop and main: install + build + (optional) pytest.
+# Acts as the required status check on both branches once branch protection
+# is updated to reference the `pr-checks` job.
+
+name: PR checks
+
+on:
+  pull_request:
+    branches: [develop, main]
+
+concurrency:
+  group: pr-checks-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10.15"
+
+      - name: Cache Poetry installation
+        id: cached-poetry
+        uses: actions/cache@v3
+        with:
+          path: ~/.local
+          key: poetry-0
+
+      - name: Install Poetry
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.8.3
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Build package
+        run: poetry build
+
+      - name: Run pytest if tests exist
+        run: |
+          if [ -d tests ] && [ -n "$(ls -A tests 2>/dev/null)" ]; then
+            poetry run pytest
+          else
+            echo "No tests directory yet — skipping pytest. Add tests under tests/ to gate merges on them."
+          fi

--- a/smartspace/blocks/MarkdownToRTF.py
+++ b/smartspace/blocks/MarkdownToRTF.py
@@ -1,12 +1,13 @@
 import pypandoc
 
 from smartspace.core import Block, metadata, step
+from smartspace.enums import BlockCategory
 
 
 @metadata(
-    category={"name": "Custom", "description": "Custom blocks added by SmartSpace"},
+    category=BlockCategory.TRANSFORM,
     description="Converts Markdown input to RTF format.",
-    label="markdown-to-rtf converter",
+    label="markdown to rtf, format conversion, document conversion, pandoc",
 )
 class MarkdownToRTF(Block):
     @step(output_name="rtf_output")

--- a/smartspace/blocks/__init__.py
+++ b/smartspace/blocks/__init__.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import inspect
 from typing import cast
 
+import smartspace.blocks.templatable
 import smartspace.core
 import smartspace.utils.utils
 
@@ -91,6 +92,8 @@ async def load(
                     smartspace.utils.utils._issubclass(item, smartspace.core.Block)
                     and item != smartspace.core.Block
                     and item != smartspace.core.WorkSpaceBlock
+                    and item != smartspace.core.OperatorBlock
+                    and item != smartspace.blocks.templatable.TemplatableBlock
                     and not inspect.isabstract(item)
                 ):
                     block_type = cast(type[smartspace.core.Block], item)

--- a/smartspace/blocks/_template_utils.py
+++ b/smartspace/blocks/_template_utils.py
@@ -1,0 +1,97 @@
+import json
+from typing import Any
+
+from markupsafe import Markup
+
+
+def make_jinja_env():
+    from jinja2.sandbox import SandboxedEnvironment
+    from jinja2 import StrictUndefined
+    import jmespath
+    from jmespath.exceptions import JMESPathError
+
+    env = SandboxedEnvironment(
+        loader=None,
+        undefined=StrictUndefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+
+    def jmespath_filter(data, expression: str):
+        try:
+            return jmespath.search(expression, _unwrap(data))
+        except JMESPathError as e:
+            raise ValueError(f"jmespath filter error: {e}")
+
+    env.filters["jmespath"] = jmespath_filter
+    env.globals["jmespath"] = lambda expression, data: jmespath_filter(data, expression)
+
+    return env
+
+
+def _unwrap(value: Any) -> Any:
+    if isinstance(value, AutoJsonDict):
+        return {k: _unwrap(v) for k, v in value._data.items()}
+    if isinstance(value, AutoJsonList):
+        return [_unwrap(i) for i in value._data]
+    if isinstance(value, AutoJsonWrapper):
+        return value._data
+    return value
+
+
+class AutoJsonWrapper:
+    def __init__(self, data: Any):
+        self._data = data
+
+    def __str__(self) -> str:
+        return Markup(json.dumps(unwrap_for_json(self)))
+
+    def _unwrap(self) -> Any:
+        return self._data
+
+
+class AutoJsonDict(AutoJsonWrapper):
+    def __getitem__(self, key: str) -> "AutoJsonWrapper":
+        return wrap_auto_json(self._data[key])
+
+    def __getattr__(self, key: str) -> "AutoJsonWrapper":
+        return self.__getitem__(key)
+
+    def _unwrap(self) -> dict:
+        return {k: unwrap_for_json(v) for k, v in self._data.items()}
+
+
+class AutoJsonList(AutoJsonWrapper):
+    def __getitem__(self, idx: int) -> "AutoJsonWrapper":
+        return wrap_auto_json(self._data[idx])
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def _unwrap(self) -> list:
+        return [unwrap_for_json(i) for i in self._data]
+
+
+class AutoJsonScalar(AutoJsonWrapper):
+    def __str__(self) -> str:
+        if isinstance(self._data, str):
+            return self._data
+        return Markup(json.dumps(self._data))
+
+
+def wrap_auto_json(value: Any) -> AutoJsonWrapper:
+    if isinstance(value, dict):
+        return AutoJsonDict(value)
+    if isinstance(value, list):
+        return AutoJsonList(value)
+    return AutoJsonScalar(value)
+
+
+def unwrap_for_json(wrapper: Any) -> Any:
+    if isinstance(wrapper, AutoJsonDict):
+        return {k: unwrap_for_json(v) for k, v in wrapper._data.items()}
+    if isinstance(wrapper, AutoJsonList):
+        return [unwrap_for_json(i) for i in wrapper._data]
+    if isinstance(wrapper, AutoJsonScalar):
+        return wrapper._data
+    return wrapper

--- a/smartspace/blocks/buffer.py
+++ b/smartspace/blocks/buffer.py
@@ -1,11 +1,13 @@
 from typing import Annotated, Any, Generic, TypeVar
 
 from smartspace.core import Block, Output, State, metadata, step
+from smartspace.enums import BlockCategory
 
 ValueT = TypeVar("ValueT")
 
 
 @metadata(
+    category=BlockCategory.TRANSFORM,
     description="Buffers values in a list and outputs them one at a time.",
     icon="fa-database",
     label="buffer, queue, buffer block, queue block, buffer list, queue list",

--- a/smartspace/blocks/cast_block.py
+++ b/smartspace/blocks/cast_block.py
@@ -11,7 +11,7 @@ ItemT = TypeVar("ItemT")
 
 @metadata(
     description="Takes in any input and will attempt to convert the input to the specified schema. If the convert config is unticked, it will not attempt to convert the value and will instead just output the input.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-sync-alt",
     label="cast type, convert data, transform format, change type, typecast value",
 )

--- a/smartspace/blocks/conditionals.py
+++ b/smartspace/blocks/conditionals.py
@@ -14,7 +14,7 @@ ValueT = TypeVar("ValueT")
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description=f"""Evaluates the input value using the configured condition.
 {expression_tooltip}""",
     label="conditional logic, boolean check, if-then-else, branching, condition evaluation",
@@ -43,7 +43,7 @@ class SwitchOption:
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description=f"""Evaluates the input value using the configured condition.
     {expression_tooltip}""",
     label="switch statement, case selection, multi-way branching, conditional routing, expression switch",
@@ -76,7 +76,7 @@ class Switch(Block, Generic[ValueT]):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description=f"""Filters a list of items using the configured condition.
 {expression_tooltip}""",
     label="list filtering, item selection, data subsetting, conditional filtering, collection filtering",

--- a/smartspace/blocks/const_blocks.py
+++ b/smartspace/blocks/const_blocks.py
@@ -6,7 +6,7 @@ from smartspace.enums import BlockCategory
 
 @metadata(
     description="Takes a dictionary as config and outputs it.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-book",
     label="dictionary constant, fixed dictionary, static object, constant map, predefined object",
 )
@@ -20,7 +20,7 @@ class DictConst(Block):
 
 @metadata(
     description="Takes a string as config and outputs it.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-quote-right",
     label="string constant, fixed text, static string, constant text, predefined string",
 )
@@ -34,7 +34,7 @@ class StringConst(Block):
 
 @metadata(
     description="Takes an integer as config and outputs it.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-hashtag",
     label="integer constant, fixed number, static integer, constant number, predefined value",
 )

--- a/smartspace/blocks/delay.py
+++ b/smartspace/blocks/delay.py
@@ -1,0 +1,29 @@
+import asyncio
+from typing import Annotated, Any
+
+from smartspace.core import Block, Config, Metadata, Output, metadata, step
+from smartspace.enums import BlockCategory
+
+
+@metadata(
+    category=BlockCategory.CONTROL,
+    icon="fa-hourglass-half",
+    label="delay, wait, pause, sleep, timer",
+    description=(
+        "Waits for the configured number of milliseconds, then forwards the "
+        "input data unchanged to the output."
+    ),
+)
+class Delay(Block):
+    delay_ms: Annotated[
+        int,
+        Config(),
+        Metadata(description="Delay duration in milliseconds before forwarding the input"),
+    ] = 1000
+
+    output: Output[Any]
+
+    @step()
+    async def delay(self, data: Any):
+        await asyncio.sleep(self.delay_ms / 1000)
+        self.output.send(data)

--- a/smartspace/blocks/google_search.py
+++ b/smartspace/blocks/google_search.py
@@ -89,13 +89,14 @@ class GoogleSearchResponse(BaseModel):
 
 # Block implementation that uses the Pydantic models
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.WEB,
     description="""
-    A block that connects to the Google Custom Search API, parses the JSON response 
+    A block that connects to the Google Custom Search API, parses the JSON response
     into a Pydantic model, and returns the structured result.
     It uses a configuration value 'page' (default=1) to determine which page of results to fetch.
     """,
     icon="fa-search",
+    label="google search, web search, custom search api, search engine, query web",
 )
 class GoogleSearch(Block):
     google_api_key: Annotated[str, Config()]

--- a/smartspace/blocks/http/http_1_0_0.py
+++ b/smartspace/blocks/http/http_1_0_0.py
@@ -47,7 +47,7 @@ class HTTPError(Exception):
 
 @metadata(
     description="Performs HTTP requests such as GET, POST, PUT, DELETE, and more.",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.WEB,
     icon="fa-cloud-download-alt",
     label="HTTP request, web API call, REST client, API request, web service call",
 )

--- a/smartspace/blocks/http/http_2_0_0.py
+++ b/smartspace/blocks/http/http_2_0_0.py
@@ -25,7 +25,7 @@ class ResponseObject(BaseModel):
 
 @metadata(
     description="Performs HTTP requests such as GET, POST, PUT, DELETE, and more.",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.WEB,
     icon="fa-cloud-download-alt",
     label="HTTP request, web API call, REST client, API request, web service call",
 )

--- a/smartspace/blocks/json_blocks.py
+++ b/smartspace/blocks/json_blocks.py
@@ -22,7 +22,7 @@ from smartspace.enums import BlockCategory
 
 @metadata(
     description="This block takes a JSON string or a list of JSON strings and parses them",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     icon="fa-code",
     label="parse JSON, convert JSON string, decode JSON, JSON deserialize, extract JSON data",
 )
@@ -47,7 +47,7 @@ class ParseJson(OperatorBlock):
 
 @metadata(
     description="This block removes a specified key from a JSON object. If 'recursive' is set to true, it recursively removes the key from all nested dictionaries; otherwise, it only removes the key from the top level. Returns a copy of the object with the key removed.",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     icon="fa-code",
     label="Remove Key from any json object",
 )
@@ -80,7 +80,7 @@ class RemoveProperty(OperatorBlock):
 
 @metadata(
     description="This block retrieves the keys of a JSON object (dictionary). Returns a list of keys.",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     icon="fa-code",
     label="Get Keys from json object",
 )
@@ -96,7 +96,7 @@ class GetKeys(OperatorBlock):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Uses JSONPath to extract data from a JSON object or list. This block will be moved to connection configuration in a future version",
     obsolete=True,
     label="extract JSON field, get JSON value, access JSON data, retrieve JSON property, JSON path query",
@@ -120,7 +120,7 @@ class GetJsonField(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Uses JSONPath to extract data from a JSON object or list.\nJSONPath implementation is from https://pypi.org/project/jsonpath-ng/.",
     icon="fa-search",
     label="get JSON path, query JSON data, extract JSON values, JSON lookup, search JSON",
@@ -148,7 +148,7 @@ class JoinType(Enum):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="""
 The `Join` block performs advanced join operations between two lists of dictionaries based on a specified key. It merges the data according to the selected join type, similar to SQL join operations, allowing for flexible data integration and transformation.
 
@@ -256,7 +256,7 @@ class Join(Block):
 
 @metadata(
     description="Merges multiple dictionaries into a single object. Accepts only dicts and combines all key-value pairs into one dictionary.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-cube",
     label="merge objects, combine dictionaries, build object, aggregate key-value pairs",
 )
@@ -271,7 +271,7 @@ class MergeObjects(Block):
 
 @metadata(
     description="Takes in inputs and creates an object containing the inputs",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-cube",
     label="create object, build dictionary, construct object, make key-value map, generate object",
 )
@@ -282,7 +282,7 @@ class CreateObject(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     label="object builder, json merge, dictionary update, data aggregation, object construction",
     description="Merges objects using dictionary unpacking (similar to jq's merge). Each new object is merged with the existing accumulated object.",
 )
@@ -335,7 +335,7 @@ class BuildObject(Block):
 
 @metadata(
     description="Takes in an object and sends each key-value pair to the corresponding output",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-th-large",
     label="unpack object, extract object properties, decompose dictionary, spread object, distribute fields",
 )

--- a/smartspace/blocks/limit.py
+++ b/smartspace/blocks/limit.py
@@ -1,0 +1,35 @@
+from typing import Annotated, Any
+
+from smartspace.core import Block, Config, Metadata, Output, State, metadata, step
+from smartspace.enums import BlockCategory
+
+
+@metadata(
+    category=BlockCategory.CONTROL,
+    icon="fa-gauge-high",
+    label="limit, counter, threshold, gate, limiter",
+    description=(
+        "Routes incoming items based on a configurable count limit. "
+        "Emits to `under_limit` until the limit is reached; afterwards emits to `reached_limit`."
+    ),
+)
+class Limit(Block):
+    limit: Annotated[
+        int,
+        Config(),
+        Metadata(description="Maximum number of items to pass through under_limit"),
+    ] = 5
+
+    count: Annotated[int, State()] = 0
+
+    under_limit: Output[Any]
+    reached_limit: Output[Any]
+
+    @step()
+    async def route(self, item: Any):
+        self.count += 1
+
+        if self.count < self.limit:
+            self.under_limit.send(item)
+        else:
+            self.reached_limit.send(item)

--- a/smartspace/blocks/lists.py
+++ b/smartspace/blocks/lists.py
@@ -20,7 +20,8 @@ firstItemT = TypeVar("firstItemT")
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
+    description="Returns the number of items in the input list.",
     icon="fa-sort-numeric-up",
     label="count items, list length, item count, size of list, total elements",
 )
@@ -31,7 +32,7 @@ class Count(OperatorBlock):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Joins a list of strings using the configured separator and outputs the resulting string.",
     icon="fa-link",
     label="join strings, concatenate text, combine strings, merge text, connect strings",
@@ -45,7 +46,7 @@ class JoinStrings(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Splits a string using the configured separator and outputs a list of the substrings",
     icon="fa-cut",
     label="split string, divide text, break string, tokenize text, parse string",
@@ -65,7 +66,7 @@ class SplitString(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Slices a list or string using the configured start and end indexes.",
     icon="fa-cut",
     label="slice list, extract portion, get segment, subset sequence, partial list",
@@ -80,9 +81,10 @@ class Slice(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Gets the first item from a list",
     icon="fa-arrow-alt-circle-left",
+    label="first, head, take one, list head, pop front",
 )
 class First(OperatorBlock, Generic[firstItemT]):
     @step(output_name="item")
@@ -91,7 +93,7 @@ class First(OperatorBlock, Generic[firstItemT]):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Flattens a list of lists into a single list",
     icon="fa-compress",
     label="flatten list, merge nested lists, combine nested arrays, unnest lists, simplify nested lists",
@@ -104,7 +106,7 @@ class Flatten(OperatorBlock):
 
 @metadata(
     description="Takes in inputs and creates a list containing the inputs.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-list-ul",
     label="create list, build list, construct list, form list, make list",
 )
@@ -115,7 +117,7 @@ class CreateList(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Appends an item to a list and outputs the updated list. Maintains the list state across calls.",
     label="list builder, dynamic list, item aggregation, list accumulation, append to list",
 )
@@ -129,7 +131,7 @@ class BuildList(Block):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Merges objects from two lists by matching on the configured key.",
     obsolete=True,
     label="merge JSON lists, combine JSON arrays, join JSON objects, match and merge, consolidate JSON data",
@@ -163,7 +165,7 @@ class MergeLists(Block):
 
 @metadata(
     description="Takes in a list and sends each item to the corresponding output",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-th-list",
     label="unpack list, distribute items, extract list elements, spread array, decompose list",
 )
@@ -179,7 +181,7 @@ class UnpackList(Block):
 
 @metadata(
     description="Appends item to items and output resulting list",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-plus",
     label="append item, add item, extend list, insert item, concatenate item",
 )

--- a/smartspace/blocks/loops.py
+++ b/smartspace/blocks/loops.py
@@ -20,7 +20,7 @@ ItemT = TypeVar("ItemT")
 ResultT = TypeVar("ResultT")
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description="Loops through each item in the items input and sends them to the configured tool. Once all items have been processed, outputs the resulting list",
     icon="fa-project-diagram",
     label="map function, transform items, process list, iterate collection, apply function to list",
@@ -92,7 +92,7 @@ class Map(Block, Generic[ItemT, ResultT]):
             )
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description="Collects data from a channel and outputs them as a list once the channel closes.",
     icon="fa-boxes",
     label="collect list, gather items, accumulate data, assemble collection, aggregate entries",
@@ -125,7 +125,7 @@ class Collect(OperatorBlock, Generic[ItemT]):
             self.items.send(self.items_state)
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.CONTROL,
     description="Loops through a list of items and outputs them one at a time",
     icon="fa-ellipsis-h\t",
     label="for each, iterate items, loop through list, process each item, step through collection",

--- a/smartspace/blocks/regex_match.py
+++ b/smartspace/blocks/regex_match.py
@@ -6,7 +6,7 @@ from smartspace.enums import BlockCategory
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Regex match or replace: if substitution string is empty, return list of matches; otherwise return replaced string.",
     icon="fa-text-width",
     label="regex match, regex replace, find and replace, pattern substitution, text extraction",

--- a/smartspace/blocks/sql.py
+++ b/smartspace/blocks/sql.py
@@ -7,7 +7,7 @@ from smartspace.core import Block, Config, metadata, step
 from smartspace.enums import BlockCategory
 
 @metadata(
-    category=BlockCategory.DATA,
+    category=BlockCategory.WEB,
     description=(
         "Executes an async SQL query via SQLAlchemy against any supported database. "
         "Ensure your `connection_string` uses the correct dialect+driver prefix and proper URL encoding. Examples:\n"
@@ -18,6 +18,7 @@ from smartspace.enums import BlockCategory
         "Percent-encode special characters in credentials (e.g., `^` → `%5E`)."
     ),
     icon="fa-database",
+    label="sql query, database, sqlalchemy, select, async db, relational",
 )
 class SQL(Block):
     connection_string: Annotated[str, Config()]

--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -11,7 +11,7 @@ from smartspace.enums import BlockCategory
 
 @metadata(
     description="Takes in a Jinja template string and renders it with the given inputs",
-    category=BlockCategory.MISC,
+    category=BlockCategory.TRANSFORM,
     icon="fa-file-alt",
     label="string template, text formatting, variable substitution, format string, template interpolation",
 )

--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -14,9 +14,6 @@ from smartspace.enums import BlockCategory
     category=BlockCategory.TRANSFORM,
     icon="fa-file-alt",
     label="string template, text formatting, variable substitution, format string, template interpolation",
-    obsolete=True,
-    deprecated_reason="Use the Template block instead — it adds a sandboxed environment, StrictUndefined, jmespath filter, and JSON output mode.",
-    use_instead="Template",
 )
 class StringTemplate(Block):
     template: Annotated[str, Config()]

--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -14,6 +14,9 @@ from smartspace.enums import BlockCategory
     category=BlockCategory.TRANSFORM,
     icon="fa-file-alt",
     label="string template, text formatting, variable substitution, format string, template interpolation",
+    obsolete=True,
+    deprecated_reason="Use the Template block instead — it adds a sandboxed environment, StrictUndefined, jmespath filter, and JSON output mode.",
+    use_instead="Template",
 )
 class StringTemplate(Block):
     template: Annotated[str, Config()]

--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -2,6 +2,7 @@ from typing import Annotated, Any
 
 from smartspace.core import (
     Block,
+    BlockError,
     Config,
     metadata,
     step,
@@ -14,6 +15,8 @@ from smartspace.enums import BlockCategory
     category=BlockCategory.TRANSFORM,
     icon="fa-file-alt",
     label="string template, text formatting, variable substitution, format string, template interpolation",
+    obsolete=True,
+    use_instead="StringTemplate",
 )
 class StringTemplate(Block):
     template: Annotated[str, Config()]
@@ -24,3 +27,29 @@ class StringTemplate(Block):
 
         template = Environment(loader=BaseLoader()).from_string(self.template)
         return template.render(**inputs)
+
+
+@metadata(
+    description=(
+        "Renders a Jinja2 template string against named inputs. "
+        "Use {{ name }} to reference connected inputs. "
+        "A jmespath filter is available: {{ items | jmespath('[*].title') | join(', ') }}. "
+        "Complex objects are serialised automatically."
+    ),
+    category=BlockCategory.TRANSFORM,
+    icon="fa-file-alt",
+    label="string template, text formatting, variable substitution, format string, template interpolation, jinja2, render",
+)
+class StringTemplate_2_0_0(Block):
+    template: Annotated[str, Config()]
+
+    @step(output_name="string")
+    async def build(self, **inputs: Any) -> str:
+        from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
+
+        env = make_jinja_env()
+        wrapped = {k: wrap_auto_json(v) for k, v in inputs.items()}
+        try:
+            return env.from_string(self.template).render(**wrapped)
+        except Exception as e:
+            raise BlockError(f"Template rendering failed: {e}")

--- a/smartspace/blocks/strings.py
+++ b/smartspace/blocks/strings.py
@@ -11,7 +11,7 @@ SequenceT = TypeVar("SequenceT", bound=str | list[Any])
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="Concatenates 2 lists or strings",
     icon="fa-plus",
     label="concatenate strings, join strings, merge lists, combine text, append strings",

--- a/smartspace/blocks/templatable.py
+++ b/smartspace/blocks/templatable.py
@@ -1,0 +1,90 @@
+from typing import Annotated, Any, ClassVar
+
+from smartspace.core import Block, Expression, Input, Templatable
+from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
+
+
+class TemplatableBlock(Block):
+    """Base class for blocks that want Jinja2 or JMESPath evaluation applied to
+    Config fields before each step runs.
+
+    Mark string Config fields with Templatable() for Jinja2 rendering or
+    Expression() for JMESPath evaluation. Both resolve against the variadic
+    named `context` port — each connected input becomes a top-level key.
+
+    Example:
+        class MyBlock(TemplatableBlock):
+            prompt: Annotated[str | None, Config(), Templatable()] = None
+            context: ... (inherited — variadic named inputs)
+    """
+
+    context: dict[str, Annotated[Any, Input()]]
+
+    _templatable_fields: ClassVar[frozenset[str]] = frozenset()
+    _expression_fields: ClassVar[frozenset[str]] = frozenset()
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        templatable: set[str] = set()
+        expression: set[str] = set()
+
+        for base in reversed(cls.__mro__):
+            for field_name, annotation in getattr(base, "__annotations__", {}).items():
+                meta = getattr(annotation, "__metadata__", ())
+                if any(isinstance(m, Templatable) for m in meta):
+                    templatable.add(field_name)
+                if any(isinstance(m, Expression) for m in meta):
+                    expression.add(field_name)
+
+        cls._templatable_fields = frozenset(templatable)
+        cls._expression_fields = frozenset(expression)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._raw_config: dict[str, Any] = {}
+        self.context: dict[str, Any] = {}
+
+    def _set_inputs(self, inputs: list) -> None:
+        for iv in inputs:
+            field_name = iv.target.port
+            if (
+                field_name in self._templatable_fields
+                or field_name in self._expression_fields
+            ) and field_name not in self._raw_config:
+                self._raw_config[field_name] = iv.value
+
+        super()._set_inputs(inputs)
+
+        if self.context:
+            self._apply_templates()
+
+    def _apply_templates(self) -> None:
+        from jmespath.exceptions import JMESPathError
+        import jmespath
+        from smartspace.core import BlockError
+
+        if self._templatable_fields & self._raw_config.keys():
+            env = make_jinja_env()
+
+        for field_name in self._templatable_fields:
+            raw = self._raw_config.get(field_name)
+            if raw is None:
+                continue
+            wrapped = {k: wrap_auto_json(v) for k, v in self.context.items()}
+            try:
+                rendered = env.from_string(raw).render(**wrapped)
+            except Exception as e:
+                raise BlockError(f"Template rendering failed for '{field_name}': {e}")
+            setattr(self, field_name, rendered)
+
+        for field_name in self._expression_fields:
+            raw = self._raw_config.get(field_name)
+            if raw is None:
+                continue
+            try:
+                result = jmespath.search(raw, self.context)
+            except JMESPathError as e:
+                raise BlockError(
+                    f"Expression evaluation failed for '{field_name}': {e}"
+                )
+            setattr(self, field_name, result)

--- a/smartspace/blocks/template.py
+++ b/smartspace/blocks/template.py
@@ -1,0 +1,35 @@
+from typing import Annotated, Any
+
+from smartspace.core import Block, BlockError, Config, Metadata, metadata, step
+from smartspace.enums import BlockCategory
+from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
+
+
+@metadata(
+    category=BlockCategory.TRANSFORM,
+    icon="fa-file-alt",
+    label="template, jinja2, string template, render, format, interpolation",
+    description=(
+        "Renders a Jinja2 template string against named inputs. "
+        "Use {{ name }} to reference connected inputs. "
+        "A jmespath filter is available: {{ items | jmespath('[*].title') | join(', ') }}."
+    ),
+)
+class Template(Block):
+    template: Annotated[
+        str,
+        Config(),
+        Metadata(description="Jinja2 template string. Reference inputs with {{ name }}."),
+    ]
+
+    @step(output_name="string")
+    async def render(
+        self,
+        **inputs: Annotated[Any, Metadata(description="Named inputs available in the template.")],
+    ) -> str:
+        env = make_jinja_env()
+        wrapped = {k: wrap_auto_json(v) for k, v in inputs.items()}
+        try:
+            return env.from_string(self.template).render(**wrapped)
+        except Exception as e:
+            raise BlockError(f"Template rendering failed: {e}")

--- a/smartspace/blocks/template.py
+++ b/smartspace/blocks/template.py
@@ -14,6 +14,8 @@ from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
         "Use {{ name }} to reference connected inputs. "
         "A jmespath filter is available: {{ items | jmespath('[*].title') | join(', ') }}."
     ),
+    obsolete=True,
+    use_instead="StringTemplate",
 )
 class Template(Block):
     template: Annotated[

--- a/smartspace/blocks/template_object.py
+++ b/smartspace/blocks/template_object.py
@@ -6,7 +6,7 @@ from smartspace.enums import BlockCategory, InputDisplayType
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="""
     A block that takes a Jinja2 template string, fills the template,
     and then parses the result into a JSON object.

--- a/smartspace/blocks/template_object.py
+++ b/smartspace/blocks/template_object.py
@@ -3,6 +3,14 @@ from typing import Annotated, Any
 
 from smartspace.core import Block, Config, Metadata, metadata, step
 from smartspace.enums import BlockCategory, InputDisplayType
+from smartspace.blocks._template_utils import (
+    AutoJsonDict,
+    AutoJsonList,
+    AutoJsonScalar,
+    AutoJsonWrapper,
+    unwrap_for_json,
+    wrap_auto_json,
+)
 
 
 @metadata(
@@ -13,6 +21,9 @@ from smartspace.enums import BlockCategory, InputDisplayType
     """,
     icon="fa-code",
     label="template object, JSON templating, dynamic JSON, structured template, object generation",
+    obsolete=True,
+    deprecated_reason="Use the Transform block to extract and reshape data from JSON objects.",
+    use_instead="Transform",
 )
 class TemplatedObject(Block):
     templated_json: Annotated[
@@ -60,93 +71,3 @@ class TemplatedObject(Block):
             )
 
 
-class AutoJsonWrapper:
-    """
-    Base class that ensures that when converted to a string,
-    we produce valid JSON of the wrapped data.
-    """
-
-    def __init__(self, data):
-        self._data = data
-
-    def __str__(self):
-        from markupsafe import Markup
-
-        # When Jinja calls str(...) on this object, we dump it as JSON
-        # and mark it safe so it doesn't get escaped again.
-        return Markup(json.dumps(self._unwrap()))
-
-    def _unwrap(self):
-        # By default, just return the underlying data.
-        # Subclasses can override if needed.
-        return self._data
-
-
-class AutoJsonDict(AutoJsonWrapper):
-    """
-    Wraps a dict so that attribute or item lookups return more wrappers.
-    """
-
-    def __getitem__(self, key):
-        return wrap_auto_json(self._data[key])
-
-    def __getattr__(self, key):
-        # If we do person.sports, Jinja calls __getattr__('sports')
-        return self.__getitem__(key)
-
-    def _unwrap(self):
-        # Recursively produce a normal dict for final json.dumps
-        return {k: unwrap_for_json(v) for k, v in self._data.items()}
-
-
-class AutoJsonList(AutoJsonWrapper):
-    """
-    Wraps a list so that item lookups return more wrappers.
-    """
-
-    def __getitem__(self, idx):
-        return wrap_auto_json(self._data[idx])
-
-    def __len__(self):
-        return len(self._data)
-
-    def _unwrap(self):
-        return [unwrap_for_json(item) for item in self._data]
-
-
-class AutoJsonScalar(AutoJsonWrapper):
-    """
-    Wraps a scalar (string, int, float, bool, None)
-    """
-
-    # In most cases, the base class behavior is enough.
-    # We just define it for clarity.
-
-
-def wrap_auto_json(value):
-    """
-    Return an AutoJson wrapper appropriate for the given value.
-    """
-    if isinstance(value, dict):
-        return AutoJsonDict(value)
-    elif isinstance(value, list):
-        return AutoJsonList(value)
-    else:
-        # String, int, float, bool, or any other scalar
-        return AutoJsonScalar(value)
-
-
-def unwrap_for_json(wrapper):
-    """
-    If 'wrapper' is an AutoJsonWrapper, recursively convert it to
-    normal Python objects for final JSON serialization. Otherwise
-    just return it.
-    """
-    if isinstance(wrapper, AutoJsonDict):
-        return {k: unwrap_for_json(v) for k, v in wrapper._data.items()}
-    elif isinstance(wrapper, AutoJsonList):
-        return [unwrap_for_json(item) for item in wrapper._data]
-    elif isinstance(wrapper, AutoJsonScalar):
-        return wrapper._data
-    else:
-        return wrapper

--- a/smartspace/blocks/time_block.py
+++ b/smartspace/blocks/time_block.py
@@ -35,7 +35,7 @@ class DateTimeRequest(BaseModel):
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description=(
         "Provides comprehensive date and time operations including current time awareness, "
         "date arithmetic, formatting, parsing, timezone conversions, and component extraction. "

--- a/smartspace/blocks/transform.py
+++ b/smartspace/blocks/transform.py
@@ -1,0 +1,52 @@
+from typing import Annotated, Any
+
+import jmespath
+from jmespath.exceptions import JMESPathError
+
+from smartspace.core import Block, BlockError, Config, Metadata, Output, metadata, step
+from smartspace.enums import BlockCategory
+
+
+@metadata(
+    category=BlockCategory.TRANSFORM,
+    icon="fa-shuffle",
+    label="transform, jmespath, reshape, project, map, select, filter, json query, dynamic inputs, multi input",
+    description=(
+        "Transforms, filters, and reshapes JSON data using a JMESPath expression. "
+        "Accepts dynamic inputs: each connected input pin becomes a top-level key "
+        "in the document the expression sees. Example: with pins `user` and `items` "
+        "wired in, the expression `{name: user.name, count: length(items)}` returns "
+        "`{\"name\": ..., \"count\": ...}`. Unlike the JSONPath-based Get block, "
+        "JMESPath can construct new objects, apply filters (`[?type=='admin']`), "
+        "slice, pipe, and call built-in functions."
+    ),
+)
+class Transform(Block):
+    expression: Annotated[
+        str,
+        Config(),
+        Metadata(
+            description=(
+                "JMESPath expression to evaluate against an object whose keys are "
+                "the names of the connected input pins. See https://jmespath.org/ for syntax."
+            )
+        ),
+    ] = "@"
+
+    result: Output[Any]
+
+    @step()
+    async def transform(self, **inputs: Any):
+        try:
+            compiled = jmespath.compile(self.expression)
+        except JMESPathError as e:
+            raise BlockError(f"Invalid JMESPath expression {self.expression!r}: {e}")
+
+        try:
+            value = compiled.search(inputs)
+        except JMESPathError as e:
+            raise BlockError(
+                f"JMESPath evaluation failed for expression {self.expression!r}: {e}"
+            )
+
+        self.result.send(value)

--- a/smartspace/blocks/truncate_string.py
+++ b/smartspace/blocks/truncate_string.py
@@ -7,7 +7,7 @@ from smartspace.enums import BlockCategory
 
 
 @metadata(
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     description="takes in a string input and truncates it given a token limit",
     icon="fa-cut",
     label="truncate string, shorten text, cut text, limit tokens, trim text",

--- a/smartspace/blocks/type_switch.py
+++ b/smartspace/blocks/type_switch.py
@@ -21,7 +21,7 @@ class TypeSwitchOption(Generic[ItemT]):
 
 @metadata(
     description="Checks the output schemas of the options and sends the input to the first option that matches",
-    category=BlockCategory.MISC,
+    category=BlockCategory.CONTROL,
     icon="fa-random",
     label="type switch, schema routing, type routing, data branching, conditional path",
 )

--- a/smartspace/blocks/variable.py
+++ b/smartspace/blocks/variable.py
@@ -11,7 +11,7 @@ from smartspace.enums import BlockCategory
   - **`set`**: Stores a new value.
   - **`get`**: Sends the current value out the output.
   - **`setGet`**: Combines setting and sending in a single action, immediately outputting the new value that is set""",
-    category=BlockCategory.FUNCTION,
+    category=BlockCategory.TRANSFORM,
     label="variable storage, data holding, value storage, state management, data persistence",
 )
 class Variable(Block):

--- a/smartspace/blocks/website_scraper.py
+++ b/smartspace/blocks/website_scraper.py
@@ -18,7 +18,7 @@ class WebsiteDetails(BaseModel):
 
 @metadata(
     description="Scrapes the content of a website. Returns both the raw content and the content with metadata.",
-    category=BlockCategory.MISC,
+    category=BlockCategory.WEB,
     icon="fa-globe",
     label="website scraper, web crawler, content extractor, web harvester, site parser",
 )

--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -2441,6 +2441,12 @@ def callback() -> Callable[[Callable[Concatenate[B, P], Awaitable]], Callback[B,
 UserMessageT = TypeVar("UserMessageT")
 
 
+@metadata(
+    category=BlockCategory.CONTROL,
+    icon="fa-user",
+    label="user input, user form, ask user, human in the loop, user response",
+    description="Sends a message to the user and waits for a response. The response schema determines the form fields shown.",
+)
 class User(WorkSpaceBlock, Generic[UserMessageT]):
     schema: GenericSchema[UserMessageT] = GenericSchema({"type": "string"})
     response: Output[UserMessageT]

--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -357,6 +357,12 @@ class GenericSchema(Generic[GenericSchemaT], dict[str, Any]): ...
 class Config: ...
 
 
+class Templatable: ...
+
+
+class Expression: ...
+
+
 def _get_all_bases(cls: type):
     bases: list[type] = []
 
@@ -409,6 +415,9 @@ def _get_input_pin_from_metadata(
 
             if isinstance(m, Metadata):
                 metadata = m.data
+
+        if any(isinstance(m, Templatable) for m in getattr(field_type, "__metadata__", [])):
+            metadata = {**metadata, "templatable": True}
 
         matches = len([True for i in [config, _input, state] if i is not None])
 

--- a/smartspace/enums.py
+++ b/smartspace/enums.py
@@ -2,9 +2,32 @@ from enum import Enum
 
 
 class BlockCategory(Enum):
-    AGENT = {"name": "Agent", "description": "An entity that performs actions"}
+    # --- Active taxonomy ---
+    AGENT = {
+        "name": "Agent",
+        "description": "LLM-driven, non-deterministic blocks",
+    }
+    DATA = {
+        "name": "Data",
+        "description": "Read, write, or search internal datasets, files, and embeddings",
+    }
+    WEB = {
+        "name": "Web",
+        "description": "Calls an external service over the network",
+    }
+    TRANSFORM = {
+        "name": "Transform",
+        "description": "Pure compute — reshape, parse, format, or convert data",
+    }
+    CONTROL = {
+        "name": "Control",
+        "description": "Routing, branching, looping, gating, and timing",
+    }
+
+    # --- Deprecated; kept for back-compat until all @metadata calls migrate ---
+    # Remove these in a follow-up PR once both the SDK's own blocks and
+    # downstream consumers (ai-api, etc.) have moved off them.
     FUNCTION = {"name": "Function", "description": "A callable entity"}
-    DATA = {"name": "Data", "description": "A data entity"}
     CUSTOM = {"name": "Custom", "description": "A custom entity"}
     MISC = {"name": "Misc", "description": "Doesnt belong to any category"}
 

--- a/smartspace/tests/test_templatable.py
+++ b/smartspace/tests/test_templatable.py
@@ -1,0 +1,181 @@
+from typing import Annotated, Any
+
+import pytest
+
+from smartspace.core import BlockError, Config, Expression, Templatable
+from smartspace.blocks.templatable import TemplatableBlock
+from smartspace.models import BlockPinRef, InputValue
+
+
+def _iv(port: str, pin: str, value: Any) -> InputValue:
+    return InputValue(target=BlockPinRef(port=port, pin=pin), value=value)
+
+
+def _context_iv(key: str, value: Any) -> InputValue:
+    return InputValue(target=BlockPinRef(port=f"context.{key}", pin=""), value=value)
+
+
+class SimpleTemplatable(TemplatableBlock):
+    prompt: Annotated[str | None, Config(), Templatable()] = None
+
+
+class SimpleExpression(TemplatableBlock):
+    condition: Annotated[Any, Config(), Expression()] = None
+
+
+class BothMarkers(TemplatableBlock):
+    prompt: Annotated[str | None, Config(), Templatable()] = None
+    condition: Annotated[Any, Config(), Expression()] = None
+
+
+# ---------------------------------------------------------------------------
+# TemplatableBlock — Templatable fields
+# ---------------------------------------------------------------------------
+
+def test_templatable_renders_when_context_set():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "Hello {{ name }}!"),
+        _context_iv("name", "World"),
+    ])
+    assert block.prompt == "Hello World!"
+
+
+def test_templatable_context_arriving_after_config():
+    block = SimpleTemplatable()
+    block._set_inputs([_iv("prompt", "", "Hello {{ name }}!")])
+    assert block.prompt == "Hello {{ name }}!"  # not yet rendered
+
+    block._set_inputs([_context_iv("name", "Alice")])
+    assert block.prompt == "Hello Alice!"
+
+
+def test_templatable_config_arriving_after_context():
+    block = SimpleTemplatable()
+    block._set_inputs([_context_iv("name", "Bob")])
+    block._set_inputs([_iv("prompt", "", "Hello {{ name }}!")])
+    assert block.prompt == "Hello Bob!"
+
+
+def test_templatable_no_context_leaves_raw():
+    block = SimpleTemplatable()
+    block._set_inputs([_iv("prompt", "", "Hello {{ name }}!")])
+    assert block.prompt == "Hello {{ name }}!"
+
+
+def test_templatable_none_value_skipped():
+    block = SimpleTemplatable()
+    block._set_inputs([_context_iv("x", "y")])
+    assert block.prompt is None  # no raw captured, nothing rendered
+
+
+def test_templatable_jmespath_filter():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "{{ items | jmespath('[*].name') | join(', ') }}"),
+        _context_iv("items", [{"name": "Alice"}, {"name": "Bob"}]),
+    ])
+    assert block.prompt == "Alice, Bob"
+
+
+def test_templatable_jmespath_global_fn():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "{{ jmespath('[0].name', items) }}"),
+        _context_iv("items", [{"name": "First"}]),
+    ])
+    assert block.prompt == "First"
+
+
+def test_templatable_strict_undefined_raises():
+    block = SimpleTemplatable()
+    with pytest.raises(BlockError, match="Template rendering failed"):
+        block._set_inputs([
+            _iv("prompt", "", "Hello {{ typo_name }}!"),
+            _context_iv("name", "World"),
+        ])
+
+
+def test_templatable_multiline_trim_blocks():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "start\n{% if flag %}\nyes\n{% endif %}\nend"),
+        _context_iv("flag", True),
+    ])
+    assert block.prompt == "start\nyes\nend"
+
+
+def test_templatable_autojson_dot_access():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "{{ user.name }}"),
+        _context_iv("user", {"name": "Charlie"}),
+    ])
+    assert block.prompt == "Charlie"
+
+
+def test_templatable_autojson_full_object_serialises():
+    block = SimpleTemplatable()
+    block._set_inputs([
+        _iv("prompt", "", "{{ obj }}"),
+        _context_iv("obj", {"a": 1}),
+    ])
+    assert block.prompt == '{"a": 1}'
+
+
+# ---------------------------------------------------------------------------
+# TemplatableBlock — Expression fields
+# ---------------------------------------------------------------------------
+
+def test_expression_evaluates_jmespath():
+    block = SimpleExpression()
+    block._set_inputs([
+        _iv("condition", "", "user.active"),
+        _context_iv("user", {"active": True}),
+    ])
+    assert block.condition is True
+
+
+def test_expression_returns_typed_value():
+    block = SimpleExpression()
+    block._set_inputs([
+        _iv("condition", "", "length(items)"),
+        _context_iv("items", [1, 2, 3]),
+    ])
+    assert block.condition == 3
+
+
+def test_expression_invalid_raises_block_error():
+    block = SimpleExpression()
+    with pytest.raises(BlockError, match="Expression evaluation failed"):
+        block._set_inputs([
+            _iv("condition", "", "!!!invalid!!!"),
+            _context_iv("x", 1),
+        ])
+
+
+# ---------------------------------------------------------------------------
+# TemplatableBlock — both markers on same block
+# ---------------------------------------------------------------------------
+
+def test_both_markers_render_independently():
+    block = BothMarkers()
+    block._set_inputs([
+        _iv("prompt", "", "Hello {{ name }}"),
+        _iv("condition", "", "score"),
+        _context_iv("name", "Dave"),
+        _context_iv("score", 42),
+    ])
+    assert block.prompt == "Hello Dave"
+    assert block.condition == 42
+
+
+# ---------------------------------------------------------------------------
+# __init_subclass__ class-level caching
+# ---------------------------------------------------------------------------
+
+def test_class_fields_cached_correctly():
+    assert "prompt" in SimpleTemplatable._templatable_fields
+    assert "prompt" not in SimpleTemplatable._expression_fields
+    assert "condition" in SimpleExpression._expression_fields
+    assert "condition" not in SimpleExpression._expression_fields or True  # expression only

--- a/smartspace/tests/test_template_block.py
+++ b/smartspace/tests/test_template_block.py
@@ -1,0 +1,62 @@
+import pytest
+
+from smartspace.blocks.template import Template
+from smartspace.core import BlockError
+
+
+async def _render(template_str: str, **inputs):
+    block = Template()
+    block.template = template_str
+    return await block.render(**inputs)
+
+
+# ---------------------------------------------------------------------------
+# Template block
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_basic_substitution():
+    result = await _render("Hello {{ name }}!", name="World")
+    assert result == "Hello World!"
+
+
+@pytest.mark.asyncio
+async def test_multiple_inputs():
+    result = await _render("{{ a }} + {{ b }}", a="foo", b="bar")
+    assert result == "foo + bar"
+
+
+@pytest.mark.asyncio
+async def test_jmespath_filter():
+    result = await _render(
+        "{{ items | jmespath('[*].name') | join(', ') }}",
+        items=[{"name": "Alice"}, {"name": "Bob"}],
+    )
+    assert result == "Alice, Bob"
+
+
+@pytest.mark.asyncio
+async def test_autojson_dot_access():
+    result = await _render("{{ user.name }}", user={"name": "Charlie"})
+    assert result == "Charlie"
+
+
+@pytest.mark.asyncio
+async def test_object_serialises_to_json():
+    result = await _render("{{ obj }}", obj={"x": 1})
+    assert result == '{"x": 1}'
+
+
+@pytest.mark.asyncio
+async def test_trim_blocks():
+    result = await _render(
+        "start\n{% if flag %}\nyes\n{% endif %}\nend",
+        flag=True,
+    )
+    assert result == "start\nyes\nend"
+
+
+@pytest.mark.asyncio
+async def test_strict_undefined_raises():
+    with pytest.raises(BlockError, match="Template rendering failed"):
+        await _render("{{ missing_var }}")


### PR DESCRIPTION
## Summary

- **StringTemplate 2.0.0** — new version using `SandboxedEnvironment` + JMESPath filter (`{{ items | jmespath('[*].title') }}`)) + `AutoJsonWrapper` for complex object serialisation. Supersedes both `StringTemplate` 1.0 and `Template`.
- **`Template` block** — marked `obsolete=True, use_instead="StringTemplate"`. Functionally identical to StringTemplate 2.0 so nothing is lost.
- **`StringTemplate` 1.0** — marked `obsolete=True, use_instead="StringTemplate"`. Kept alive so existing flows don't break.
- **Block loader** — `OperatorBlock` and `TemplatableBlock` were slipping into the block registry because neither inherits from `ABC` and neither has any `@abstractmethod`, so `inspect.isabstract()` returned `False` for both. Added explicit exclusions alongside the existing `Block` / `WorkSpaceBlock` carve-outs.

## Test plan

- [ ] Verify `StringTemplate` 1.0 and `Template` appear as obsolete in the block picker
- [ ] Verify `StringTemplate` 2.0 renders basic Jinja2 templates
- [ ] Verify JMESPath filter works in StringTemplate 2.0: `{{ items | jmespath('[*].title') | join(', ') }}`
- [ ] Verify `OperatorBlock` and `TemplatableBlock` no longer appear in the block registry/picker