### PR TITLE
Add SendEmail block for sending email over SMTP

### DIFF
--- a/smartspace/blocks/send_email.py
+++ b/smartspace/blocks/send_email.py
@@ -1,0 +1,133 @@
+import asyncio
+import smtplib
+import ssl
+from email.message import EmailMessage
+from typing import Annotated, Optional
+
+from pydantic import BaseModel
+from smartspace.core import Block, BlockError, Config, Metadata, metadata, step
+from smartspace.enums import BlockCategory
+
+
+class EmailResult(BaseModel):
+    sent: bool
+    recipients: list[str]
+    subject: str
+
+
+@metadata(
+    category=BlockCategory.FUNCTION,
+    description=(
+        "Sends an email over SMTP. Configure the SMTP server, credentials, and "
+        "sender once, then provide recipients, subject, and body at run time. "
+        "Supports STARTTLS, implicit SSL, CC/BCC, and HTML bodies."
+    ),
+    icon="fa-envelope",
+    label="send email, smtp, email notification, mail, send message, smtplib, email block",
+)
+class SendEmail(Block):
+    smtp_host: Annotated[
+        str, Config(), Metadata(description="SMTP server hostname, e.g. smtp.office365.com")
+    ]
+    smtp_port: Annotated[
+        int, Config(), Metadata(description="SMTP server port (587 for STARTTLS, 465 for SSL, 25 plain)")
+    ] = 587
+    from_address: Annotated[
+        str, Config(), Metadata(description="The 'From' email address messages are sent as")
+    ]
+    username: Annotated[
+        str, Config(), Metadata(description="SMTP auth username. Leave empty for unauthenticated servers.")
+    ] = ""
+    password: Annotated[
+        str, Config(), Metadata(description="SMTP auth password or app password")
+    ] = ""
+    use_tls: Annotated[
+        bool, Config(), Metadata(description="Upgrade the connection with STARTTLS after connecting")
+    ] = True
+    use_ssl: Annotated[
+        bool, Config(), Metadata(description="Connect using implicit SSL/TLS (SMTP_SSL). Overrides STARTTLS.")
+    ] = False
+    is_html: Annotated[
+        bool, Config(), Metadata(description="Treat the body as HTML instead of plain text")
+    ] = False
+    timeout: Annotated[
+        int, Config(), Metadata(description="Connection timeout in seconds")
+    ] = 30
+
+    @step(output_name="result")
+    async def send(
+        self,
+        to: Annotated[
+            list[str], Metadata(description="Primary recipient email addresses")
+        ],
+        subject: Annotated[str, Metadata(description="Email subject line")],
+        body: Annotated[str, Metadata(description="Email body (plain text or HTML)")],
+        cc: Annotated[
+            Optional[list[str]], Metadata(description="CC recipient email addresses")
+        ] = None,
+        bcc: Annotated[
+            Optional[list[str]], Metadata(description="BCC recipient email addresses")
+        ] = None,
+    ) -> EmailResult:
+        if not self.smtp_host:
+            raise BlockError("smtp_host is required")
+        if not self.from_address:
+            raise BlockError("from_address is required")
+
+        to = to or []
+        cc = cc or []
+        bcc = bcc or []
+
+        recipients = [address for address in (*to, *cc, *bcc) if address]
+        if not recipients:
+            raise BlockError("At least one recipient (to, cc, or bcc) is required")
+
+        message = EmailMessage()
+        message["From"] = self.from_address
+        message["To"] = ", ".join(to)
+        if cc:
+            message["Cc"] = ", ".join(cc)
+        message["Subject"] = subject
+        if self.is_html:
+            message.set_content(
+                "This email requires an HTML-capable email client to view."
+            )
+            message.add_alternative(body, subtype="html")
+        else:
+            message.set_content(body)
+
+        try:
+            await asyncio.to_thread(self._send_message, message, recipients)
+        except smtplib.SMTPAuthenticationError:
+            raise BlockError(
+                "SMTP authentication failed. Check the username and password."
+            )
+        except smtplib.SMTPException as e:
+            raise BlockError(f"Failed to send email: {e}")
+        except OSError as e:
+            raise BlockError(f"Could not connect to SMTP server {self.smtp_host}:{self.smtp_port}: {e}")
+
+        return EmailResult(sent=True, recipients=recipients, subject=subject)
+
+    def _send_message(self, message: EmailMessage, recipients: list[str]) -> None:
+        if self.use_ssl:
+            context = ssl.create_default_context()
+            server: smtplib.SMTP = smtplib.SMTP_SSL(
+                self.smtp_host, self.smtp_port, timeout=self.timeout, context=context
+            )
+        else:
+            server = smtplib.SMTP(self.smtp_host, self.smtp_port, timeout=self.timeout)
+
+        try:
+            server.ehlo()
+            if self.use_tls and not self.use_ssl:
+                context = ssl.create_default_context()
+                server.starttls(context=context)
+                server.ehlo()
+            if self.username:
+                server.login(self.username, self.password)
+            server.send_message(
+                message, from_addr=self.from_address, to_addrs=recipients
+            )
+        finally:
+            server.quit()

--- a/smartspace/tests/test_send_email.py
+++ b/smartspace/tests/test_send_email.py
@@ -1,0 +1,130 @@
+import smtplib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from smartspace.core import BlockError
+from smartspace.blocks.send_email import SendEmail
+
+
+def _make_block(**overrides) -> SendEmail:
+    block = SendEmail()
+    block.smtp_host = "smtp.example.com"
+    block.smtp_port = 587
+    block.from_address = "sender@example.com"
+    block.username = "sender@example.com"
+    block.password = "secret"
+    block.use_tls = True
+    block.use_ssl = False
+    block.is_html = False
+    block.timeout = 30
+    for key, value in overrides.items():
+        setattr(block, key, value)
+    return block
+
+
+@pytest.mark.asyncio
+async def test_send_email_starttls_flow():
+    block = _make_block()
+    server = MagicMock()
+
+    with patch("smartspace.blocks.send_email.smtplib.SMTP", return_value=server) as smtp:
+        result = await block.send(
+            to=["a@example.com"],
+            subject="Hello",
+            body="Body text",
+        )
+
+    smtp.assert_called_once_with("smtp.example.com", 587, timeout=30)
+    server.starttls.assert_called_once()
+    server.login.assert_called_once_with("sender@example.com", "secret")
+    server.send_message.assert_called_once()
+    server.quit.assert_called_once()
+
+    assert result.sent is True
+    assert result.recipients == ["a@example.com"]
+    assert result.subject == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_send_email_combines_recipients():
+    block = _make_block()
+    server = MagicMock()
+
+    with patch("smartspace.blocks.send_email.smtplib.SMTP", return_value=server):
+        result = await block.send(
+            to=["a@example.com"],
+            subject="Hi",
+            body="Body",
+            cc=["b@example.com"],
+            bcc=["c@example.com"],
+        )
+
+    _, kwargs = server.send_message.call_args
+    assert kwargs["to_addrs"] == ["a@example.com", "b@example.com", "c@example.com"]
+    assert result.recipients == ["a@example.com", "b@example.com", "c@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_send_email_uses_ssl_when_configured():
+    block = _make_block(use_ssl=True, smtp_port=465)
+    server = MagicMock()
+
+    with (
+        patch("smartspace.blocks.send_email.smtplib.SMTP_SSL", return_value=server) as smtp_ssl,
+        patch("smartspace.blocks.send_email.smtplib.SMTP") as smtp_plain,
+    ):
+        await block.send(to=["a@example.com"], subject="S", body="B")
+
+    smtp_ssl.assert_called_once()
+    smtp_plain.assert_not_called()
+    server.starttls.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_email_skips_login_without_username():
+    block = _make_block(username="", password="")
+    server = MagicMock()
+
+    with patch("smartspace.blocks.send_email.smtplib.SMTP", return_value=server):
+        await block.send(to=["a@example.com"], subject="S", body="B")
+
+    server.login.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_email_html_body():
+    block = _make_block(is_html=True)
+    server = MagicMock()
+
+    with patch("smartspace.blocks.send_email.smtplib.SMTP", return_value=server):
+        await block.send(
+            to=["a@example.com"],
+            subject="S",
+            body="<h1>Hi</h1>",
+        )
+
+    sent_message = server.send_message.call_args.args[0]
+    assert sent_message.get_content_type() == "multipart/alternative"
+
+
+@pytest.mark.asyncio
+async def test_send_email_requires_recipient():
+    block = _make_block()
+
+    with pytest.raises(BlockError):
+        await block.send(to=[], subject="S", body="B")
+
+
+@pytest.mark.asyncio
+async def test_send_email_wraps_auth_error():
+    block = _make_block()
+    server = MagicMock()
+    server.login.side_effect = smtplib.SMTPAuthenticationError(535, b"bad creds")
+
+    with patch("smartspace.blocks.send_email.smtplib.SMTP", return_value=server):
+        with pytest.raises(BlockError) as exc:
+            await block.send(to=["a@example.com"], subject="S", body="B")
+
+    assert "authentication failed" in exc.value.message.lower()
+    server.quit.assert_called_once()


### PR DESCRIPTION
## What

Adds a new **`SendEmail`** block (`smartspace.blocks.send_email`) so workflows can send email.

`smtplib` is part of the Python standard library, so no new dependency is needed — this PR adds the block that wraps it.

## How it works

- **Configs** (set once per block): `smtp_host`, `smtp_port` (default 587), `from_address`, `username`, `password`, `use_tls` (STARTTLS, default on), `use_ssl` (implicit SSL, overrides STARTTLS), `is_html`, `timeout`.
- **Step inputs** (per send): `to`, `subject`, `body`, optional `cc`, `bcc`.
- **Output**: `EmailResult { sent, recipients, subject }`.

Details:
- Blocking `smtplib` calls run via `asyncio.to_thread` so the step stays non-blocking, per SDK async rules.
- SMTP/connection failures are wrapped in `BlockError` with actionable messages; auth failures are called out specifically. The connection is always closed via `quit()`.
- HTML bodies use `EmailMessage.add_alternative` with a plain-text fallback.

## Tests

`smartspace/tests/test_send_email.py` mocks `smtplib` and covers: STARTTLS flow, implicit SSL, recipient combination (to/cc/bcc), unauthenticated servers, HTML bodies, missing-recipient validation, and auth-error wrapping.

## Notes

- Targets `develop`.
- Couldn't run the suite locally (host only has Python 3.12; SDK pins `<3.12` and uses the devcontainer) — relying on CI for the test run.