### PR TITLE
fix(blocks): type UnpackObject outputs as Any instead of dict

### DIFF
--- a/smartspace/blocks/json_blocks.py
+++ b/smartspace/blocks/json_blocks.py
@@ -340,7 +340,7 @@ class BuildObject(Block):
     label="unpack object, extract object properties, decompose dictionary, spread object, distribute fields",
 )
 class UnpackObject(Block):
-    properties: dict[str, Output[dict[str, Any]]]
+    properties: dict[str, Output[Any]]
 
     @step()
     async def unpack(self, object: dict[str, Any]):


### PR DESCRIPTION
## Problem
Every output added to the **UnpackObject** block gets a schema of empty `object`, because the dynamic outputs are declared as `Output[dict[str, Any]]`. Each output actually emits a single property value from the unpacked object, which can be any type.

## Fix
Type the outputs as `Output[Any]`, matching the existing pattern in `UnpackList` (`items: list[Output[Any]]`). The block input (`object: dict[str, Any]`) is unchanged and still maps to an `object` schema.