### PR TITLE
feat: Secret() config marker + SecretRef type

### DIFF
--- a/smartspace/__init__.py
+++ b/smartspace/__init__.py
@@ -1,0 +1,7 @@
+from smartspace.core import Secret
+from smartspace.models import SecretRef
+
+__all__ = [
+    "Secret",
+    "SecretRef",
+]

--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -357,7 +357,11 @@ class GenericSchema(Generic[GenericSchemaT], dict[str, Any]): ...
 class Config: ...
 
 
-class Secret: ...
+class Secret:
+    """Marks a Config pin as secret-typed (class-attribute Config pins only).
+
+    Usage: `api_key: Annotated[SecretRef, Config(), Secret()]`
+    """
 
 
 class Templatable: ...
@@ -422,7 +426,10 @@ def _get_input_pin_from_metadata(
         if any(isinstance(m, Templatable) for m in getattr(field_type, "__metadata__", [])):
             metadata = {**metadata, "templatable": True}
 
-        if any(isinstance(m, Secret) for m in getattr(field_type, "__metadata__", [])):
+        if any(
+            isinstance(m, Secret) or m is Secret
+            for m in getattr(field_type, "__metadata__", [])
+        ):
             metadata = {**metadata, "secret": True}
 
         matches = len([True for i in [config, _input, state] if i is not None])

--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -357,6 +357,9 @@ class GenericSchema(Generic[GenericSchemaT], dict[str, Any]): ...
 class Config: ...
 
 
+class Secret: ...
+
+
 class Templatable: ...
 
 
@@ -418,6 +421,9 @@ def _get_input_pin_from_metadata(
 
         if any(isinstance(m, Templatable) for m in getattr(field_type, "__metadata__", [])):
             metadata = {**metadata, "templatable": True}
+
+        if any(isinstance(m, Secret) for m in getattr(field_type, "__metadata__", [])):
+            metadata = {**metadata, "secret": True}
 
         matches = len([True for i in [config, _input, state] if i is not None])
 

--- a/smartspace/models.py
+++ b/smartspace/models.py
@@ -3,7 +3,8 @@ from datetime import datetime
 from typing import Annotated, Any, Generic, TypeVar, Union
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_serializer
+from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler, model_serializer
+from pydantic_core import core_schema
 
 from smartspace.enums import (
     BlockClass,
@@ -14,6 +15,22 @@ from smartspace.enums import (
     StreamingEvent,
 )
 from smartspace.utils.utils import _get_type_adapter
+
+
+class SecretRef(str):
+    """A reference to a secret, e.g. the name of a secret configured in the workspace.
+
+    Behaves exactly like ``str`` at runtime and on the wire (validates and
+    serializes as a plain string, JSON schema is ``{"type": "string"}``), but
+    gives block authors a distinct type to pair with the ``Secret()`` config
+    marker: ``api_key: Annotated[SecretRef, Config(), Secret()]``.
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.str_schema()
 
 
 class File(BaseModel):

--- a/smartspace/tests/test_secret.py
+++ b/smartspace/tests/test_secret.py
@@ -1,0 +1,80 @@
+from typing import Annotated
+
+from pydantic import TypeAdapter
+
+from smartspace.core import Block, Config, Metadata, Secret, metadata, step
+from smartspace.enums import BlockCategory
+from smartspace.models import SecretRef
+
+
+@metadata(description="test block with a secret config", category=BlockCategory.MISC)
+class SecretConfigBlock(Block):
+    api_key: Annotated[SecretRef, Config(), Secret()]
+    plain: Annotated[str, Config()]
+    documented_key: Annotated[
+        SecretRef, Config(), Secret(), Metadata(display_name="API key")
+    ]
+
+    @step(output_name="out")
+    async def run(self, x: str) -> str:
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Secret() marker — pin interface metadata
+# ---------------------------------------------------------------------------
+
+def test_secret_pin_metadata_has_secret_and_config():
+    interface = SecretConfigBlock.interface()
+    pin = interface.ports["api_key"].inputs[""]
+    assert pin.metadata["secret"] is True
+    assert pin.metadata["config"] is True
+
+
+def test_plain_config_pin_has_no_secret_key():
+    interface = SecretConfigBlock.interface()
+    pin = interface.ports["plain"].inputs[""]
+    assert "secret" not in pin.metadata
+    assert pin.metadata["config"] is True
+
+
+def test_secret_composes_with_metadata():
+    interface = SecretConfigBlock.interface()
+    pin = interface.ports["documented_key"].inputs[""]
+    assert pin.metadata["secret"] is True
+    assert pin.metadata["config"] is True
+    assert pin.metadata["display_name"] == "API key"
+
+
+def test_interface_serializes_with_secret_flag():
+    interface = SecretConfigBlock.interface()
+    dumped = interface.model_dump(by_alias=True)
+    pin_metadata = dumped["ports"]["api_key"]["inputs"][""]["metadata"]
+    assert pin_metadata["secret"] is True
+    assert pin_metadata["config"] is True
+
+
+# ---------------------------------------------------------------------------
+# SecretRef — plain-string semantics
+# ---------------------------------------------------------------------------
+
+def test_secret_ref_validates_from_str():
+    adapter = TypeAdapter(SecretRef)
+    assert adapter.validate_python("my-secret-token") == "my-secret-token"
+
+
+def test_secret_ref_serializes_as_plain_string():
+    adapter = TypeAdapter(SecretRef)
+    assert adapter.dump_python(SecretRef("my-secret-token")) == "my-secret-token"
+    assert adapter.dump_json(SecretRef("my-secret-token")) == b'"my-secret-token"'
+
+
+def test_secret_ref_json_schema_is_plain_string():
+    adapter = TypeAdapter(SecretRef)
+    assert adapter.json_schema() == {"type": "string"}
+
+
+def test_secret_ref_pin_schema_is_plain_string():
+    interface = SecretConfigBlock.interface()
+    pin = interface.ports["api_key"].inputs[""]
+    assert pin.json_schema == {"type": "string"}

--- a/smartspace/tests/test_secret.py
+++ b/smartspace/tests/test_secret.py
@@ -78,3 +78,40 @@ def test_secret_ref_pin_schema_is_plain_string():
     interface = SecretConfigBlock.interface()
     pin = interface.ports["api_key"].inputs[""]
     assert pin.json_schema == {"type": "string"}
+
+
+# ---------------------------------------------------------------------------
+# Guard rails
+# ---------------------------------------------------------------------------
+
+def test_bare_class_secret_marker_still_flags_pin():
+    class BareMarkerBlock(Block):
+        api_key: Annotated[SecretRef, Config(), Secret]
+
+        @step(output_name="out")
+        async def run(self, x: str) -> str:
+            return x
+
+    pin = BareMarkerBlock.interface().ports["api_key"].inputs[""]
+    assert pin.metadata["secret"] is True
+
+
+def test_secret_pin_with_default_is_optional_and_keeps_flag():
+    class DefaultedBlock(Block):
+        api_key: Annotated[SecretRef, Config(), Secret()] = SecretRef("")
+
+        @step(output_name="out")
+        async def run(self, x: str) -> str:
+            return x
+
+    pin = DefaultedBlock.interface().ports["api_key"].inputs[""]
+    assert pin.metadata["secret"] is True
+    assert pin.required is False
+
+
+def test_package_root_exports():
+    import smartspace
+
+    assert smartspace.Secret is Secret
+    assert smartspace.SecretRef is SecretRef
+    assert set(smartspace.__all__) >= {"Secret", "SecretRef"}


### PR DESCRIPTION
## What

Adds a `Secret()` config marker and `SecretRef` type so block authors can declare secret-typed config:

```python
api_key: Annotated[SecretRef, Config(), Secret()]
```

The marker sets `metadata["secret"] = True` on the pin interface (mirroring how `Templatable` works), which the frontend reads to render a secret picker instead of a plain text field. `SecretRef` validates and serialises as a plain string, so it flows through existing pin-binding untouched.

This is **PR 3 of 3** in the Key Vault secrets work (Nous ticket 2521368701). It is the SDK-side surface only — the resolver (`resolve_secret()` / runtime resolution) is deliberately deferred to a later PR, so this ships no dead API.

## Design

Full rationale: `Smartspace-ai-api/.claude/plans/key-vault-secrets.md` (PR 3 section). Two permanent credential paths: Connections (for registered operations, value never enters the flow) and this block-secret path (for custom/non-operation blocks). This PR builds the block-secret path's authoring surface.

## Changes
- `smartspace/core.py` — `class Secret` marker + detection branch (bare-class `Secret` without `()` is also flagged, so a missing-parens typo can't silently downgrade a secret field to a plain one)
- `smartspace/models.py` — `SecretRef(str)` with a plain-string pydantic schema
- `smartspace/__init__.py` — exports `Secret`, `SecretRef`
- `smartspace/tests/test_secret.py` — 11 tests

## Review
Built and adversarially reviewed (correctness + conventions); one fix taken pre-merge (bare-class guard). ai-api consumes the SDK via `rev = "develop"`, so no version bump is needed here.

## Tests
84 passed (1 pre-existing failure on develop, unrelated: `test_markdown_to_rtf_block`).

## Follow-ups noted (separate)
- `jmespath` missing from `pyproject.toml` (22 pre-existing tests fail on a clean install)
- CI `pr-checks.yml` looks for a top-level `tests/` dir but tests live in `smartspace/tests/`, so the suite never gates PRs