### PR TITLE
chore: add jmespath dep, run pytest in CI, fix stale markdown-rtf test

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,10 +43,5 @@ jobs:
       - name: Build package
         run: poetry build
 
-      - name: Run pytest if tests exist
-        run: |
-          if [ -d tests ] && [ -n "$(ls -A tests 2>/dev/null)" ]; then
-            poetry run pytest
-          else
-            echo "No tests directory yet — skipping pytest. Add tests under tests/ to gate merges on them."
-          fi
+      - name: Run pytest
+        run: poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -1667,6 +1667,17 @@ files = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
+    {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.2"
 description = "Lightweight pipelining with Python functions"
@@ -5211,4 +5222,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "4fef4fccadc64364c941d3462abf1c223fc48bf01f597c460f7c08f7feddae85"
+content-hash = "508c258765f6cfe46e8a628fa0b8e24233f4f28b4794534bf8d56c44281b0600"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.pytest.ini_options]
 testpaths = [
-    "tests",
+    "smartspace/tests",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning"
@@ -26,6 +26,7 @@ beautifulsoup4 = "^4.12.0"
 mypy = "^1.8.0"
 mypy-extensions = "1.0.0"
 numpy = "^1.26.0"
+jmespath = "^1.0.1"
 jsonschema = "^4.23.0"
 typer = "0.16.0"
 azure-identity = "^1.17.1"

--- a/smartspace/tests/test_markdown_to_rtf_block.py
+++ b/smartspace/tests/test_markdown_to_rtf_block.py
@@ -60,12 +60,16 @@ async def test_markdown_to_rtf_single_run_enforced(ensure_pandoc):
 
 
 def test_markdown_to_rtf_metadata_and_step_properties():
+    from smartspace.enums import BlockCategory
+
     # Class-level metadata attached by @metadata
     meta = getattr(MarkdownToRTF, "metadata", {})
-    assert meta.get("label") == "markdown-to-rtf converter"
+    assert (
+        meta.get("label")
+        == "markdown to rtf, format conversion, document conversion, pandoc"
+    )
     assert meta.get("description") == "Converts Markdown input to RTF format."
-    assert isinstance(meta.get("category"), dict)
-    assert meta["category"].get("name") == "Custom"
+    assert meta.get("category") is BlockCategory.TRANSFORM
 
     # Step exists and has correct output name per decorator
     block = MarkdownToRTF()


### PR DESCRIPTION
## What

Repo-health fixes surfaced while reviewing the `Secret()` marker PR (#281). Independent of that work.

1. **Add `jmespath` as a direct dependency.** `smartspace/blocks/transform.py` imports it at top level (unguarded), and `templatable.py` / `_template_utils.py` use it too — but it was missing from `pyproject.toml`, surviving only on a transitive dep. On a clean `poetry install` without that transitive, importing the blocks package fails (22 tests error with `ModuleNotFoundError`). Added `jmespath = "^1.0.1"` (resolves to 1.1.0) and locked it.
2. **Make CI actually run the test suite.** `pr-checks.yml` gated pytest behind `if [ -d tests ]` at the repo root, but tests live in `smartspace/tests/` — so the suite never ran and never gated PRs. Fixed `testpaths` and made the pytest step unconditional.
3. **Fix the stale `test_markdown_to_rtf` metadata test.** Turning CI on surfaced a pre-existing failure: the test asserted a label/category that no longer match the block (commit e048943 changed the block and left the test behind). Updated the assertions to the block's current metadata; the output-name assertion was already correct.

## Why together
These three are mutually dependent: turning CI on (2) without the dep (1) and the stale-test fix (3) would make the newly-required check red. They ship as one branch.

## Lockfile note
Locked with Poetry 1.8.3 (matching the CI pin) in an isolated env, so `poetry.lock` stays lock-version 2.0 and `poetry 1.8.3 check --lock` passes. The diff is only the jmespath package block — no unrelated churn.

## Tests
Full suite green: `poetry run pytest` → 74 passed, 0 failed on this branch. Reviewed independently (verdict SHIP; lockfile CI-compatibility verified).