### PR TITLE
Release: develop → main (v0.1.12)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,10 +43,5 @@ jobs:
       - name: Build package
         run: poetry build
 
-      - name: Run pytest if tests exist
-        run: |
-          if [ -d tests ] && [ -n "$(ls -A tests 2>/dev/null)" ]; then
-            poetry run pytest
-          else
-            echo "No tests directory yet — skipping pytest. Add tests under tests/ to gate merges on them."
-          fi
+      - name: Run pytest
+        run: poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -1667,6 +1667,17 @@ files = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
+    {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.2"
 description = "Lightweight pipelining with Python functions"
@@ -5211,4 +5222,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "4fef4fccadc64364c941d3462abf1c223fc48bf01f597c460f7c08f7feddae85"
+content-hash = "508c258765f6cfe46e8a628fa0b8e24233f4f28b4794534bf8d56c44281b0600"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ filterwarnings = [
 
 [tool.poetry]
 name = "smartspace-ai"
-version = "0.1.11"
+version = "0.1.12"
 description = "Smartspace SDK"
 readme = "README.md"
 packages = [{ include = "smartspace" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.pytest.ini_options]
 testpaths = [
-    "tests",
+    "smartspace/tests",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning"
@@ -26,6 +26,7 @@ beautifulsoup4 = "^4.12.0"
 mypy = "^1.8.0"
 mypy-extensions = "1.0.0"
 numpy = "^1.26.0"
+jmespath = "^1.0.1"
 jsonschema = "^4.23.0"
 typer = "0.16.0"
 azure-identity = "^1.17.1"

--- a/smartspace/__init__.py
+++ b/smartspace/__init__.py
@@ -1,0 +1,7 @@
+from smartspace.core import Secret
+from smartspace.models import SecretRef
+
+__all__ = [
+    "Secret",
+    "SecretRef",
+]

--- a/smartspace/blocks/json_blocks.py
+++ b/smartspace/blocks/json_blocks.py
@@ -340,7 +340,7 @@ class BuildObject(Block):
     label="unpack object, extract object properties, decompose dictionary, spread object, distribute fields",
 )
 class UnpackObject(Block):
-    properties: dict[str, Output[dict[str, Any]]]
+    properties: dict[str, Output[Any]]
 
     @step()
     async def unpack(self, object: dict[str, Any]):

--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -15,8 +15,6 @@ from smartspace.enums import BlockCategory
     category=BlockCategory.TRANSFORM,
     icon="fa-file-alt",
     label="string template, text formatting, variable substitution, format string, template interpolation",
-    obsolete=True,
-    use_instead="StringTemplate",
 )
 class StringTemplate(Block):
     template: Annotated[str, Config()]

--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -357,7 +357,11 @@ class GenericSchema(Generic[GenericSchemaT], dict[str, Any]): ...
 class Config: ...
 
 
-class Secret: ...
+class Secret:
+    """Marks a Config pin as secret-typed (class-attribute Config pins only).
+
+    Usage: `api_key: Annotated[SecretRef, Config(), Secret()]`
+    """
 
 
 class Templatable: ...
@@ -422,7 +426,10 @@ def _get_input_pin_from_metadata(
         if any(isinstance(m, Templatable) for m in getattr(field_type, "__metadata__", [])):
             metadata = {**metadata, "templatable": True}
 
-        if any(isinstance(m, Secret) for m in getattr(field_type, "__metadata__", [])):
+        if any(
+            isinstance(m, Secret) or m is Secret
+            for m in getattr(field_type, "__metadata__", [])
+        ):
             metadata = {**metadata, "secret": True}
 
         matches = len([True for i in [config, _input, state] if i is not None])

--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -357,6 +357,9 @@ class GenericSchema(Generic[GenericSchemaT], dict[str, Any]): ...
 class Config: ...
 
 
+class Secret: ...
+
+
 class Templatable: ...
 
 
@@ -418,6 +421,9 @@ def _get_input_pin_from_metadata(
 
         if any(isinstance(m, Templatable) for m in getattr(field_type, "__metadata__", [])):
             metadata = {**metadata, "templatable": True}
+
+        if any(isinstance(m, Secret) for m in getattr(field_type, "__metadata__", [])):
+            metadata = {**metadata, "secret": True}
 
         matches = len([True for i in [config, _input, state] if i is not None])
 

--- a/smartspace/models.py
+++ b/smartspace/models.py
@@ -3,7 +3,8 @@ from datetime import datetime
 from typing import Annotated, Any, Generic, TypeVar, Union
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_serializer
+from pydantic import BaseModel, ConfigDict, Field, GetCoreSchemaHandler, model_serializer
+from pydantic_core import core_schema
 
 from smartspace.enums import (
     BlockClass,
@@ -14,6 +15,22 @@ from smartspace.enums import (
     StreamingEvent,
 )
 from smartspace.utils.utils import _get_type_adapter
+
+
+class SecretRef(str):
+    """A reference to a secret, e.g. the name of a secret configured in the workspace.
+
+    Behaves exactly like ``str`` at runtime and on the wire (validates and
+    serializes as a plain string, JSON schema is ``{"type": "string"}``), but
+    gives block authors a distinct type to pair with the ``Secret()`` config
+    marker: ``api_key: Annotated[SecretRef, Config(), Secret()]``.
+    """
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.str_schema()
 
 
 class File(BaseModel):

--- a/smartspace/tests/test_markdown_to_rtf_block.py
+++ b/smartspace/tests/test_markdown_to_rtf_block.py
@@ -60,12 +60,16 @@ async def test_markdown_to_rtf_single_run_enforced(ensure_pandoc):
 
 
 def test_markdown_to_rtf_metadata_and_step_properties():
+    from smartspace.enums import BlockCategory
+
     # Class-level metadata attached by @metadata
     meta = getattr(MarkdownToRTF, "metadata", {})
-    assert meta.get("label") == "markdown-to-rtf converter"
+    assert (
+        meta.get("label")
+        == "markdown to rtf, format conversion, document conversion, pandoc"
+    )
     assert meta.get("description") == "Converts Markdown input to RTF format."
-    assert isinstance(meta.get("category"), dict)
-    assert meta["category"].get("name") == "Custom"
+    assert meta.get("category") is BlockCategory.TRANSFORM
 
     # Step exists and has correct output name per decorator
     block = MarkdownToRTF()

--- a/smartspace/tests/test_secret.py
+++ b/smartspace/tests/test_secret.py
@@ -1,0 +1,80 @@
+from typing import Annotated
+
+from pydantic import TypeAdapter
+
+from smartspace.core import Block, Config, Metadata, Secret, metadata, step
+from smartspace.enums import BlockCategory
+from smartspace.models import SecretRef
+
+
+@metadata(description="test block with a secret config", category=BlockCategory.MISC)
+class SecretConfigBlock(Block):
+    api_key: Annotated[SecretRef, Config(), Secret()]
+    plain: Annotated[str, Config()]
+    documented_key: Annotated[
+        SecretRef, Config(), Secret(), Metadata(display_name="API key")
+    ]
+
+    @step(output_name="out")
+    async def run(self, x: str) -> str:
+        return x
+
+
+# ---------------------------------------------------------------------------
+# Secret() marker — pin interface metadata
+# ---------------------------------------------------------------------------
+
+def test_secret_pin_metadata_has_secret_and_config():
+    interface = SecretConfigBlock.interface()
+    pin = interface.ports["api_key"].inputs[""]
+    assert pin.metadata["secret"] is True
+    assert pin.metadata["config"] is True
+
+
+def test_plain_config_pin_has_no_secret_key():
+    interface = SecretConfigBlock.interface()
+    pin = interface.ports["plain"].inputs[""]
+    assert "secret" not in pin.metadata
+    assert pin.metadata["config"] is True
+
+
+def test_secret_composes_with_metadata():
+    interface = SecretConfigBlock.interface()
+    pin = interface.ports["documented_key"].inputs[""]
+    assert pin.metadata["secret"] is True
+    assert pin.metadata["config"] is True
+    assert pin.metadata["display_name"] == "API key"
+
+
+def test_interface_serializes_with_secret_flag():
+    interface = SecretConfigBlock.interface()
+    dumped = interface.model_dump(by_alias=True)
+    pin_metadata = dumped["ports"]["api_key"]["inputs"][""]["metadata"]
+    assert pin_metadata["secret"] is True
+    assert pin_metadata["config"] is True
+
+
+# ---------------------------------------------------------------------------
+# SecretRef — plain-string semantics
+# ---------------------------------------------------------------------------
+
+def test_secret_ref_validates_from_str():
+    adapter = TypeAdapter(SecretRef)
+    assert adapter.validate_python("my-secret-token") == "my-secret-token"
+
+
+def test_secret_ref_serializes_as_plain_string():
+    adapter = TypeAdapter(SecretRef)
+    assert adapter.dump_python(SecretRef("my-secret-token")) == "my-secret-token"
+    assert adapter.dump_json(SecretRef("my-secret-token")) == b'"my-secret-token"'
+
+
+def test_secret_ref_json_schema_is_plain_string():
+    adapter = TypeAdapter(SecretRef)
+    assert adapter.json_schema() == {"type": "string"}
+
+
+def test_secret_ref_pin_schema_is_plain_string():
+    interface = SecretConfigBlock.interface()
+    pin = interface.ports["api_key"].inputs[""]
+    assert pin.json_schema == {"type": "string"}

--- a/smartspace/tests/test_secret.py
+++ b/smartspace/tests/test_secret.py
@@ -78,3 +78,40 @@ def test_secret_ref_pin_schema_is_plain_string():
     interface = SecretConfigBlock.interface()
     pin = interface.ports["api_key"].inputs[""]
     assert pin.json_schema == {"type": "string"}
+
+
+# ---------------------------------------------------------------------------
+# Guard rails
+# ---------------------------------------------------------------------------
+
+def test_bare_class_secret_marker_still_flags_pin():
+    class BareMarkerBlock(Block):
+        api_key: Annotated[SecretRef, Config(), Secret]
+
+        @step(output_name="out")
+        async def run(self, x: str) -> str:
+            return x
+
+    pin = BareMarkerBlock.interface().ports["api_key"].inputs[""]
+    assert pin.metadata["secret"] is True
+
+
+def test_secret_pin_with_default_is_optional_and_keeps_flag():
+    class DefaultedBlock(Block):
+        api_key: Annotated[SecretRef, Config(), Secret()] = SecretRef("")
+
+        @step(output_name="out")
+        async def run(self, x: str) -> str:
+            return x
+
+    pin = DefaultedBlock.interface().ports["api_key"].inputs[""]
+    assert pin.metadata["secret"] is True
+    assert pin.required is False
+
+
+def test_package_root_exports():
+    import smartspace
+
+    assert smartspace.Secret is Secret
+    assert smartspace.SecretRef is SecretRef
+    assert set(smartspace.__all__) >= {"Secret", "SecretRef"}


### PR DESCRIPTION
Standing release PR — **created manually** because the `open-standing-release-pr.yml` automation currently fails at the PR-creation step (org setting *"Allow GitHub Actions to create and approve pull requests"* is off; see note below). The branch itself is exactly what the workflow produced: `develop` HEAD + the auto version bump to **0.1.12**.

**Merging this PR releases `v0.1.12` to PyPI** (via `release.yml`) and cuts the matching GitHub release/tag.

## What ships in 0.1.12 (develop ahead of main since 0.1.11)
- **#281 — `Secret()` config marker + `SecretRef` type** (the reason for this release: unblocks secret-typed block config for template/PyPI consumers, e.g. `smartspace-template`).
- **#282 — repo-health**: `jmespath` added as a direct dep, CI now runs the test suite, stale markdown-rtf test fixed.
- **#280 — `UnpackObject` outputs typed `Any`**, and a StringTemplate 1.0 flag cleanup.

## ⚠ Automation fix needed (separate)
The standing-release workflow force-pushes `release/next` and bumps the version fine, but its final `gh pr create` fails: *"GitHub Actions is not permitted to create or approve pull requests."* Enable **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** (repo or org level) so future releases open this PR automatically. Until then the PR must be opened by hand, as here.