### PR TITLE
feat: FlowConstant.secret marks a constant as a managed-secret reference

### DIFF
--- a/smartspace/models.py
+++ b/smartspace/models.py
@@ -512,6 +512,16 @@ class FlowConstant(BaseModel):
 
     value: Any
 
+    # Flow-author intent: this constant holds an `ss://secret/{name}` managed-secret
+    # reference and should be resolved to the real value when it binds to a block
+    # pin. Set when an input is switched to "Secret" mode in the flow editor.
+    #
+    # The marker — rather than resolving on value shape alone — is what keeps
+    # resolution to values that come from the flow *definition*. Runtime data
+    # (user input, upstream block outputs) is never marked, so it can never be
+    # made to resolve a secret by containing a reference-shaped string.
+    secret: bool = False
+
 
 class FlowInput(BaseModel):
     model_config = ConfigDict(populate_by_name=True)

--- a/smartspace/tests/test_flow_constant_secret.py
+++ b/smartspace/tests/test_flow_constant_secret.py
@@ -1,0 +1,25 @@
+from smartspace.models import FlowConstant
+
+
+def test_secret_defaults_to_false():
+    assert FlowConstant(value="hello").secret is False
+
+
+def test_secret_can_be_set():
+    constant = FlowConstant(value="ss://secret/my-key", secret=True)
+    assert constant.secret is True
+    assert constant.value == "ss://secret/my-key"
+
+
+def test_existing_flows_without_the_field_deserialize_as_not_secret():
+    # Backward compat: flow definitions saved before the field existed must load
+    # with secret=False, so nothing already in the wild starts resolving.
+    constant = FlowConstant.model_validate({"value": "ss://secret/my-key"})
+    assert constant.secret is False
+
+
+def test_round_trips_through_dump_and_validate():
+    original = FlowConstant(value="ss://secret/my-key", secret=True)
+    restored = FlowConstant.model_validate(original.model_dump(by_alias=True))
+    assert restored.secret is True
+    assert restored.value == original.value


### PR DESCRIPTION
## What

Adds `secret: bool = False` to `FlowConstant`. It records **flow-author intent**: this constant holds an `ss://secret/{name}` reference and should be resolved to the real value when it binds to a block pin.

This is **PR A of 3**, enabling a flow author to switch *any* input to "Secret" mode in the editor — parallel to the existing `Variable` mode — instead of secrets only being usable where a *block author* declared a `Secret()` field.

- **B** (ai-api): union flow-marked constant targets into the existing resolution gate.
- **C** (app): add `Secret` to the pin's `inputType` toggle + the picker + the mutation that writes `{ value: 'ss://secret/<name>', secret: true }`.

## Why a marker, and not "resolve any `ss://secret/…` we find"

Resolving on value-shape alone would scan **runtime data too**. An end user typing `ss://secret/prod-key` into a chat message that reaches a block pin would resolve the real credential — an injection vector, and the scrubber can't help because the block may send it outbound by design.

GitHub Actions avoids exactly this by resolving `${{ secrets.X }}` from the **workflow definition**, never from data. Marking the constant gives the same property: only values that come from the flow definition can resolve. Runtime data (user input, upstream block outputs) is never marked.

## Compatibility
Defaults to `False`, so every flow definition already in the wild loads as non-secret and nothing starts resolving. Tested explicitly.

## Tests
4 tests: default is `False`; explicit set; **old flow JSON without the field deserializes as `secret=False`**; dump/validate round-trip. Full SDK suite green (89 passed).