### PR TITLE
Add playwright as a runtime dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3148,6 +3148,27 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.4.2)", "pytest-
 type = ["mypy (>=1.18.2)"]
 
 [[package]]
+name = "playwright"
+version = "1.61.0"
+description = "A high-level API to automate web browsers"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0"},
+    {file = "playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a"},
+    {file = "playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af"},
+    {file = "playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e"},
+    {file = "playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c"},
+    {file = "playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b"},
+    {file = "playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597"},
+    {file = "playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51"},
+]
+
+[package.dependencies]
+greenlet = ">=3.1.1,<4.0.0"
+pyee = ">=13,<14"
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
@@ -3534,6 +3555,23 @@ azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0
 gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
 toml = ["tomli (>=2.0.1)"]
 yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228"},
+    {file = "pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "mypy", "pytest", "pytest-asyncio", "pytest-trio", "sphinx", "toml", "tox", "trio", "trio", "trio-typing", "twine", "twisted", "validate-pyproject[all]"]
 
 [[package]]
 name = "pygments"
@@ -5222,4 +5260,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "508c258765f6cfe46e8a628fa0b8e24233f4f28b4794534bf8d56c44281b0600"
+content-hash = "236f4ca2c0ceded77b6069d7315036d650536e8f234e103feffdb73b10d5716b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ filterwarnings = [
 
 [tool.poetry]
 name = "smartspace-ai"
-version = "0.1.11"
+version = "0.1.12"
 description = "Smartspace SDK"
 readme = "README.md"
 packages = [{ include = "smartspace" }]
@@ -53,6 +53,7 @@ docxtpl = "^0.19.0"
 python-docx = "^1.1.2"
 aiomysql = "^0.2.0"
 lark = "1.1.9"
+playwright = "^1.53.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.0"


### PR DESCRIPTION
## What

Adds `playwright = "^1.53.0"` to the SDK's runtime dependencies and bumps the package version to **0.1.12** (the release workflow publishes to PyPI from the pyproject version, so the bump is required for the change to actually ship).

Lock file regenerated with Poetry 1.8.3 (same as CI) via `poetry lock --no-update` — only playwright 1.61.0 and its new transitive dep pyee are added; all existing pins untouched.

## Why

Custom blocks execute in-process inside the ai-api runtime, which already installs playwright `^1.53.0` plus Chromium and its OS deps (used by the native `HeadlessBrowserService`). So `import playwright` already works in published custom blocks today — but only as an accident of the ai-api's dependency set. Declaring it in the SDK makes it an official, typed part of the block-development surface, and pip-installable in block dev containers.

The constraint matches the ai-api's existing pin, so the ai-api's git dependency on this repo keeps resolving.

## Follow-ups (not in this PR)

- **smartspace-template dev container**: has no browsers, and its `python:3.10-buster` base is Debian 10, which modern Playwright doesn't support — needs a bookworm bump plus `playwright install --with-deps chromium` before `smartspace blocks debug` works with Playwright blocks locally.
- Consider a shared browser/page service in the SDK so blocks don't each launch their own Chromium in the shared ai-api container (memory/orphaned-process risk).