### PR TITLE
feat(core): declare config-pin languages for the flow designer

### DIFF
--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -4,10 +4,11 @@ from smartspace.core import (
     Block,
     BlockError,
     Config,
+    Metadata,
     metadata,
     step,
 )
-from smartspace.enums import BlockCategory
+from smartspace.enums import BlockCategory, InputLanguage
 
 
 @metadata(
@@ -17,7 +18,7 @@ from smartspace.enums import BlockCategory
     label="string template, text formatting, variable substitution, format string, template interpolation",
 )
 class StringTemplate(Block):
-    template: Annotated[str, Config()]
+    template: Annotated[str, Config(), Metadata(language=InputLanguage.JINJA)]
 
     @step(output_name="string")
     async def build(self, **inputs: Any) -> str:
@@ -39,7 +40,7 @@ class StringTemplate(Block):
     label="string template, text formatting, variable substitution, format string, template interpolation, jinja2, render",
 )
 class StringTemplate_2_0_0(Block):
-    template: Annotated[str, Config()]
+    template: Annotated[str, Config(), Metadata(language=InputLanguage.JINJA)]
 
     @step(output_name="string")
     async def build(self, **inputs: Any) -> str:

--- a/smartspace/blocks/transform.py
+++ b/smartspace/blocks/transform.py
@@ -4,7 +4,7 @@ import jmespath
 from jmespath.exceptions import JMESPathError
 
 from smartspace.core import Block, BlockError, Config, Metadata, Output, metadata, step
-from smartspace.enums import BlockCategory
+from smartspace.enums import BlockCategory, InputLanguage
 
 
 @metadata(
@@ -26,10 +26,15 @@ class Transform(Block):
         str,
         Config(),
         Metadata(
+            language=InputLanguage.JMESPATH,
             description=(
                 "JMESPath expression to evaluate against an object whose keys are "
-                "the names of the connected input pins. See https://jmespath.org/ for syntax."
-            )
+                "the names of the connected input pins. See https://jmespath.org/ for syntax. "
+                "Note that string literals use SINGLE quotes — double quotes denote a field "
+                "reference, so \"Bearer \" is a lookup for a field of that name, not text. "
+                "There is no {placeholder} interpolation; concatenate with "
+                "join(' ', ['Bearer', token])."
+            ),
         ),
     ] = "@"
 

--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -35,6 +35,7 @@ from smartspace.enums import (
     BlockScope,
     ChannelEvent,
     InputDisplayType,
+    InputLanguage,
     StreamingEvent,
 )
 from smartspace.models import (
@@ -425,6 +426,11 @@ def _get_input_pin_from_metadata(
 
         if any(isinstance(m, Templatable) for m in getattr(field_type, "__metadata__", [])):
             metadata = {**metadata, "templatable": True}
+            metadata.setdefault("language", InputLanguage.JINJA)
+
+        if any(isinstance(m, Expression) for m in getattr(field_type, "__metadata__", [])):
+            metadata = {**metadata, "expression": True}
+            metadata.setdefault("language", InputLanguage.JMESPATH)
 
         if any(
             isinstance(m, Secret) or m is Secret

--- a/smartspace/enums.py
+++ b/smartspace/enums.py
@@ -74,3 +74,30 @@ class BlockScope(Enum):
 
 class InputDisplayType(Enum):
     TEMPLATEOBJECT = "TemplateObject"
+
+
+class InputLanguage(Enum):
+    """The language a string Config pin holds.
+
+    A render hint for the flow designer: it selects the code editor's grammar,
+    so the pin gets syntax highlighting, completion and inline errors instead of
+    a plain text box. Purely presentational — nothing at runtime reads it.
+
+    Distinct from InputDisplayType, which selects *which widget* renders a pin;
+    this selects *which grammar* the text is in.
+
+    Stamped automatically for fields marked Templatable() (JINJA) or
+    Expression() (JMESPATH). Set it explicitly with Metadata(language=...) on
+    pins that carry a language without using those markers.
+
+    Consumers must treat an unrecognised value as plain text — blocks built
+    against a newer SDK will emit languages an older designer doesn't know.
+    """
+
+    JMESPATH = "jmespath"
+    JINJA = "jinja"
+    DATASET_FILTER = "datasetFilter"
+    DATASET_SORT = "datasetSort"
+    SQL = "sql"
+    PYTHON = "python"
+    JSON = "json"

--- a/smartspace/tests/test_input_language.py
+++ b/smartspace/tests/test_input_language.py
@@ -1,0 +1,89 @@
+from typing import Annotated
+
+from smartspace.blocks.string_template import StringTemplate, StringTemplate_2_0_0
+from smartspace.blocks.transform import Transform
+from smartspace.core import (
+    Block,
+    Config,
+    Expression,
+    Metadata,
+    Templatable,
+    metadata,
+    step,
+)
+from smartspace.enums import BlockCategory, InputLanguage
+
+
+@metadata(description="test block with language-bearing configs", category=BlockCategory.MISC)
+class LanguageConfigBlock(Block):
+    templated: Annotated[str, Config(), Templatable()]
+    expression: Annotated[str, Config(), Expression()]
+    plain: Annotated[str, Config()]
+    # An explicit language must win over the marker's default.
+    overridden: Annotated[
+        str, Config(), Templatable(), Metadata(language=InputLanguage.JMESPATH)
+    ]
+
+    @step(output_name="out")
+    async def run(self, x: str) -> str:
+        return x
+
+
+def _pin(block: type[Block], name: str):
+    return block.interface().ports[name].inputs[""]
+
+
+# ---------------------------------------------------------------------------
+# Markers stamp the language automatically
+# ---------------------------------------------------------------------------
+
+
+def test_templatable_pin_is_tagged_jinja():
+    pin = _pin(LanguageConfigBlock, "templated")
+    assert pin.metadata["templatable"] is True
+    assert pin.metadata["language"] == InputLanguage.JINJA
+
+
+def test_expression_pin_is_tagged_jmespath():
+    pin = _pin(LanguageConfigBlock, "expression")
+    assert pin.metadata["expression"] is True
+    assert pin.metadata["language"] == InputLanguage.JMESPATH
+
+
+def test_plain_config_pin_has_no_language():
+    pin = _pin(LanguageConfigBlock, "plain")
+    assert "language" not in pin.metadata
+    assert pin.metadata["config"] is True
+
+
+def test_explicit_language_beats_marker_default():
+    pin = _pin(LanguageConfigBlock, "overridden")
+    assert pin.metadata["templatable"] is True
+    assert pin.metadata["language"] == InputLanguage.JMESPATH
+
+
+# ---------------------------------------------------------------------------
+# Real blocks carry the tag the flow designer keys off
+# ---------------------------------------------------------------------------
+
+
+def test_transform_expression_is_jmespath():
+    assert _pin(Transform, "expression").metadata["language"] == InputLanguage.JMESPATH
+
+
+def test_string_template_is_jinja():
+    assert _pin(StringTemplate, "template").metadata["language"] == InputLanguage.JINJA
+    assert (
+        _pin(StringTemplate_2_0_0, "template").metadata["language"]
+        == InputLanguage.JINJA
+    )
+
+
+# ---------------------------------------------------------------------------
+# The value that crosses the wire is the plain string the designer compares to
+# ---------------------------------------------------------------------------
+
+
+def test_language_serialises_to_its_string_value():
+    dumped = Transform.interface().model_dump(mode="json")
+    assert dumped["ports"]["expression"]["inputs"][""]["metadata"]["language"] == "jmespath"


### PR DESCRIPTION
Adds an `InputLanguage` enum and stamps it into input-pin metadata so the flow designer can render a real code editor — highlighting, completion, inline errors — instead of a plain text box.

## Why this is small

The SDK already declared these languages *semantically*: `Templatable()` means Jinja, `Expression()` means JMESPath. Neither reached the block interface, so the designer had nothing to key off.

Both markers now stamp `language` automatically, which covers every current and future block using them — no per-block tagging. Only three pins needed an explicit tag.

## Changes

- **`InputLanguage` enum** — `jmespath`, `jinja`, `datasetFilter`, `datasetSort`, `sql`, `python`, `json`. Separate from `InputDisplayType`, which selects *which widget* renders a pin; this selects *which grammar* the text is in.
- **Automatic stamping** — `Templatable()` → `JINJA`, `Expression()` → `JMESPATH`. An explicit `Metadata(language=...)` wins over the marker default.
- **`Expression()` now stamps `expression: true`**, mirroring the `templatable: true` that `Templatable()` already emitted. It was previously invisible in the interface entirely.
- **Explicit tags** on the blocks that carry a language without using the markers: `Transform` (JMESPath) and both `StringTemplate` versions (Jinja).
- **Documents the JMESPath quoting trap** on `Transform.expression`.

## The bug that motivated it

```
{"Authorization": "Bearer {hubspotToken}", "Content-Type": "application/json"}
```

Valid JMESPath. Evaluates to `{"Authorization": null, "Content-Type": null}` — double quotes are a *field reference*, not a string literal, and there is no `{placeholder}` interpolation. Silent at runtime, invisible in the editor.

## Compatibility

Purely additive. Nothing at runtime reads `language`, and consumers are required to treat unrecognised values as plain text, so a block built against a newer SDK degrades gracefully in an older designer rather than breaking the config drawer.

## Tests

96 pass (89 existing + 7 new). The new suite covers automatic stamping, explicit override, absence on plain configs, the real blocks, and that the enum serialises across the wire as the plain string `"jmespath"`.

## Follow-ups (not in this PR)

- ai-api: tag `GetDataSet.filter`/`.sort` and `SearchDataSet.filter` — needs this merged plus a lock refresh
- Smartspace-app: the CodeMirror renderer that consumes `language` (ready, staged locally)