### PR TITLE
feat(core): JSONPATH input language; tag Get.path

### DIFF
--- a/smartspace/blocks/json_blocks.py
+++ b/smartspace/blocks/json_blocks.py
@@ -17,7 +17,7 @@ from smartspace.core import (
     metadata,
     step,
 )
-from smartspace.enums import BlockCategory
+from smartspace.enums import BlockCategory, InputLanguage
 
 
 @metadata(
@@ -126,7 +126,17 @@ class GetJsonField(Block):
     label="get JSON path, query JSON data, extract JSON values, JSON lookup, search JSON",
 )
 class Get(OperatorBlock):
-    path: Annotated[str, Config()]
+    path: Annotated[
+        str,
+        Config(),
+        Metadata(
+            language=InputLanguage.JSONPATH,
+            description=(
+                "JSONPath expression evaluated with jsonpath-ng's extended "
+                "dialect. Start from the root with $ (e.g. $.items[*].name)."
+            ),
+        ),
+    ]
 
     @step(output_name="result")
     async def get(self, data: list[Any] | dict[str, Any]) -> Any:

--- a/smartspace/enums.py
+++ b/smartspace/enums.py
@@ -96,6 +96,7 @@ class InputLanguage(Enum):
 
     JMESPATH = "jmespath"
     JINJA = "jinja"
+    JSONPATH = "jsonpath"
     DATASET_FILTER = "datasetFilter"
     DATASET_SORT = "datasetSort"
     SQL = "sql"

--- a/smartspace/tests/test_input_language.py
+++ b/smartspace/tests/test_input_language.py
@@ -87,3 +87,10 @@ def test_string_template_is_jinja():
 def test_language_serialises_to_its_string_value():
     dumped = Transform.interface().model_dump(mode="json")
     assert dumped["ports"]["expression"]["inputs"][""]["metadata"]["language"] == "jmespath"
+
+
+def test_get_path_is_jsonpath():
+    from smartspace.blocks.json_blocks import Get
+
+    pin = _pin(Get, "path")
+    assert pin.metadata["language"] == InputLanguage.JSONPATH


### PR DESCRIPTION
Completes the language coverage from #286: `InputLanguage` gains `JSONPATH` and `Get.path` declares it, with the dialect documented on the pin (jsonpath-ng **extended** — which is why the designer ships highlighting + completion but deliberately no client-side compile check: JS JSONPath libraries implement different dialects and would mis-lint).

One enum member, one tag, one test. 97 tests pass.