### PR TITLE
feat(core): condition/regex/SQL languages + syntax guides for every language pin

### DIFF
--- a/smartspace/blocks/conditionals.py
+++ b/smartspace/blocks/conditionals.py
@@ -3,11 +3,12 @@ from typing import Annotated, Any, Generic, TypeVar
 from smartspace.core import (
     Block,
     Config,
+    Metadata,
     Output,
     metadata,
     step,
 )
-from smartspace.enums import BlockCategory
+from smartspace.enums import BlockCategory, InputLanguage
 from smartspace.utils.expressions import evaluate_expression, expression_tooltip
 
 ValueT = TypeVar("ValueT")
@@ -20,7 +21,14 @@ ValueT = TypeVar("ValueT")
     label="conditional logic, boolean check, if-then-else, branching, condition evaluation",
 )
 class If(Block, Generic[ValueT]):
-    condition: Annotated[str, Config()] = "value"
+    condition: Annotated[
+        str,
+        Config(),
+        Metadata(
+            language=InputLanguage.CONDITION,
+            description=expression_tooltip,
+        ),
+    ] = "value"
     false: Output[ValueT]
     true: Output[ValueT]
 
@@ -38,7 +46,14 @@ class If(Block, Generic[ValueT]):
 
 
 class SwitchOption:
-    condition: Annotated[str, Config()] = "value == "
+    condition: Annotated[
+        str,
+        Config(),
+        Metadata(
+            language=InputLanguage.CONDITION,
+            description=expression_tooltip,
+        ),
+    ] = "value == "
     output: Output[Any]
 
 
@@ -82,7 +97,14 @@ class Switch(Block, Generic[ValueT]):
     label="list filtering, item selection, data subsetting, conditional filtering, collection filtering",
 )
 class Filter(Block, Generic[ValueT]):
-    condition: Annotated[str, Config()] = "value"
+    condition: Annotated[
+        str,
+        Config(),
+        Metadata(
+            language=InputLanguage.CONDITION,
+            description=expression_tooltip,
+        ),
+    ] = "value"
 
     @step(output_name="items")
     async def create_response(self, items: list[ValueT]) -> list[ValueT]:

--- a/smartspace/blocks/json_blocks.py
+++ b/smartspace/blocks/json_blocks.py
@@ -132,8 +132,15 @@ class Get(OperatorBlock):
         Metadata(
             language=InputLanguage.JSONPATH,
             description=(
-                "JSONPath expression evaluated with jsonpath-ng's extended "
-                "dialect. Start from the root with $ (e.g. $.items[*].name)."
+                "JSONPath expression, e.g. $.items[*].name.\n"
+                "\n"
+                "$ is the root; .field / ['field'] descend; [*] every element; "
+                "[0] an index; $..name searches recursively; "
+                "$.items[?(@.price > 10)] filters (@ = the current element).\n"
+                "\n"
+                "Evaluated with jsonpath-ng's extended dialect. A dict input "
+                "returns the first match (null if none); a list input returns "
+                "every match."
             ),
         ),
     ]

--- a/smartspace/blocks/regex_match.py
+++ b/smartspace/blocks/regex_match.py
@@ -2,7 +2,7 @@ import re
 from typing import Annotated
 
 from smartspace.core import Block, Config, Metadata, metadata, step
-from smartspace.enums import BlockCategory
+from smartspace.enums import BlockCategory, InputLanguage
 
 
 @metadata(
@@ -17,7 +17,22 @@ class RegexMatch(Block):
     pattern and substitution string.
     """
 
-    regex: Annotated[str, Config()] = (
+    regex: Annotated[
+        str,
+        Config(),
+        Metadata(
+            language=InputLanguage.REGEX,
+            description=(
+                "Python regular expression (re module syntax), e.g. "
+                r"\b(\w+)@(\w+\.\w+)\b."
+                "\n"
+                "Named groups are (?P<name>...); backreferences in "
+                "replace_with are \\1 or \\g<name>. With replace_with empty "
+                "the block returns the list of matches; otherwise the "
+                "replaced string."
+            ),
+        ),
+    ] = (
         r".*"  # Default pattern to match the entire string
     )
     replace_with: Annotated[

--- a/smartspace/blocks/sql.py
+++ b/smartspace/blocks/sql.py
@@ -3,8 +3,8 @@ from decimal import Decimal
 from typing import Annotated, Any, Dict, List, Union
 
 
-from smartspace.core import Block, Config, metadata, step
-from smartspace.enums import BlockCategory
+from smartspace.core import Block, Config, Metadata, metadata, step
+from smartspace.enums import BlockCategory, InputLanguage
 
 @metadata(
     category=BlockCategory.WEB,
@@ -22,7 +22,25 @@ from smartspace.enums import BlockCategory
 )
 class SQL(Block):
     connection_string: Annotated[str, Config()]
-    query: Annotated[str, Config()]
+    query: Annotated[
+        str,
+        Config(),
+        Metadata(
+            language=InputLanguage.SQL,
+            description=(
+                "SQL statement, e.g. "
+                "SELECT * FROM orders WHERE status = :status.\n"
+                "\n"
+                ":name placeholders are bind parameters — each one is filled "
+                "from the block's input pin of the same name, safely "
+                "parameterised (never string-interpolated).\n"
+                "\n"
+                "Runs against the connection_string database, so use that "
+                "engine's dialect. SELECTs return a list of row objects; "
+                "other statements return the affected row count."
+            ),
+        ),
+    ]
 
     @step(output_name="result")
     async def run(self, **params) -> Union[List[Dict[str, Any]], int]:

--- a/smartspace/blocks/string_template.py
+++ b/smartspace/blocks/string_template.py
@@ -18,7 +18,24 @@ from smartspace.enums import BlockCategory, InputLanguage
     label="string template, text formatting, variable substitution, format string, template interpolation",
 )
 class StringTemplate(Block):
-    template: Annotated[str, Config(), Metadata(language=InputLanguage.JINJA)]
+    template: Annotated[
+        str,
+        Config(),
+        Metadata(
+            language=InputLanguage.JINJA,
+            description=(
+                "Jinja template. Reference connected inputs with {{ name }} and "
+                "nested fields with {{ name.field }}.\n"
+                "\n"
+                "Logic: {% if x %}...{% endif %}, {% for item in items %}"
+                "{{ item }}{% endfor %}. Filters with |, e.g. "
+                "{{ items | join(', ') }}.\n"
+                "\n"
+                "Referencing a variable that isn't wired in fails when the "
+                "block runs."
+            ),
+        ),
+    ]
 
     @step(output_name="string")
     async def build(self, **inputs: Any) -> str:
@@ -40,7 +57,25 @@ class StringTemplate(Block):
     label="string template, text formatting, variable substitution, format string, template interpolation, jinja2, render",
 )
 class StringTemplate_2_0_0(Block):
-    template: Annotated[str, Config(), Metadata(language=InputLanguage.JINJA)]
+    template: Annotated[
+        str,
+        Config(),
+        Metadata(
+            language=InputLanguage.JINJA,
+            description=(
+                "Jinja template. Reference connected inputs with {{ name }} and "
+                "nested fields with {{ name.field }}.\n"
+                "\n"
+                "Logic: {% if x %}...{% endif %}, {% for item in items %}"
+                "{{ item }}{% endfor %}. Filters with |, e.g. "
+                "{{ items | join(', ') }} or "
+                "{{ items | jmespath('[*].title') | join(', ') }}.\n"
+                "\n"
+                "Complex objects serialise automatically. Referencing a "
+                "variable that isn't wired in fails when the block runs."
+            ),
+        ),
+    ]
 
     @step(output_name="string")
     async def build(self, **inputs: Any) -> str:

--- a/smartspace/enums.py
+++ b/smartspace/enums.py
@@ -97,6 +97,8 @@ class InputLanguage(Enum):
     JMESPATH = "jmespath"
     JINJA = "jinja"
     JSONPATH = "jsonpath"
+    CONDITION = "condition"
+    REGEX = "regex"
     DATASET_FILTER = "datasetFilter"
     DATASET_SORT = "datasetSort"
     SQL = "sql"

--- a/smartspace/tests/test_input_language.py
+++ b/smartspace/tests/test_input_language.py
@@ -94,3 +94,21 @@ def test_get_path_is_jsonpath():
 
     pin = _pin(Get, "path")
     assert pin.metadata["language"] == InputLanguage.JSONPATH
+
+
+def test_sql_condition_and_regex_pins_are_tagged():
+    from smartspace.blocks.conditionals import Filter, If
+    from smartspace.blocks.regex_match import RegexMatch
+    from smartspace.blocks.sql import SQL
+
+    assert _pin(SQL, "query").metadata["language"] == InputLanguage.SQL
+    assert _pin(If, "condition").metadata["language"] == InputLanguage.CONDITION
+    assert _pin(Filter, "condition").metadata["language"] == InputLanguage.CONDITION
+    assert _pin(RegexMatch, "regex").metadata["language"] == InputLanguage.REGEX
+
+
+def test_condition_pins_carry_the_expression_guide():
+    from smartspace.blocks.conditionals import If
+    from smartspace.utils.expressions import expression_tooltip
+
+    assert _pin(If, "condition").metadata["description"] == expression_tooltip


### PR DESCRIPTION
Completes the language audit started in #286/#287.

**Newly declared languages** (were in daily use, never on the enum):
- `CONDITION` — the Lark grammar behind **If / Switch / Filter** (`value.user.age > 18`, `~=`, `len()`, `in`). Pins tagged, with the existing `expression_tooltip` attached as the pin guide.
- `REGEX` — `RegexMatch.regex`, with a Python-`re`-dialect guide.
- **SQL** (member existed, pin untagged) — `SQL.query`, guide documents the undiscoverable part: `:name` placeholders bind to the input pin of the same name (verified against the step; lists expand for IN).

**Guides for pins that had editors but no words:** StringTemplate v1/v2 (Jinja), Get.path (fattened).

99 tests pass (2 new). Frontend editors for sql/condition/regex land on Smartspace-app#1697.