### PR TITLE
Templatable()/Expression() on @step parameters and dict/list pins

### DIFF
--- a/smartspace/blocks/templatable.py
+++ b/smartspace/blocks/templatable.py
@@ -1,27 +1,63 @@
+import inspect
 from typing import Annotated, Any, ClassVar
 
-from smartspace.core import Block, Expression, Input, Templatable
+from smartspace.core import (
+    Block,
+    BlockFunction,
+    Expression,
+    Input,
+    Templatable,
+)
 from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
+from smartspace.utils.utils import _issubclass
+
+
+def _render_value(env: Any, raw: Any, wrapped_context: dict[str, Any]) -> Any:
+    """Render a Templatable value against the context.
+
+    Strings are rendered as Jinja2 templates. Dicts and lists are walked and
+    their string leaves rendered, so a dict-typed pin (e.g. HTTP headers) can
+    carry templates in its values. Dict keys are never rendered. Anything else
+    passes through untouched.
+    """
+    if isinstance(raw, str):
+        return env.from_string(raw).render(**wrapped_context)
+    if isinstance(raw, dict):
+        return {k: _render_value(env, v, wrapped_context) for k, v in raw.items()}
+    if isinstance(raw, list):
+        return [_render_value(env, v, wrapped_context) for v in raw]
+    return raw
 
 
 class TemplatableBlock(Block):
     """Base class for blocks that want Jinja2 or JMESPath evaluation applied to
-    Config fields before each step runs.
+    input pins before each step runs.
 
-    Mark string Config fields with Templatable() for Jinja2 rendering or
-    Expression() for JMESPath evaluation. Both resolve against the variadic
-    named `context` port — each connected input becomes a top-level key.
+    Mark string pins with Templatable() for Jinja2 rendering or Expression()
+    for JMESPath evaluation. Both work on class-attribute pins (Config or
+    Input) and on @step parameters, and resolve against the variadic named
+    `context` port — each connected input becomes a top-level key.
+
+    Dict- and list-typed Templatable pins are walked and their string leaves
+    rendered, so e.g. header or query-param dicts can carry templates in
+    their values.
 
     Example:
         class MyBlock(TemplatableBlock):
             prompt: Annotated[str | None, Config(), Templatable()] = None
-            context: ... (inherited — variadic named inputs)
+            # context: ... (inherited — variadic named inputs)
+
+            @step(output_name="response")
+            async def run(self, url: Annotated[str, Templatable()]) -> str: ...
     """
 
     context: dict[str, Annotated[Any, Input()]]
 
     _templatable_fields: ClassVar[frozenset[str]] = frozenset()
     _expression_fields: ClassVar[frozenset[str]] = frozenset()
+    # step/callback port name -> parameter names carrying the marker
+    _templatable_step_params: ClassVar[dict[str, frozenset[str]]] = {}
+    _expression_step_params: ClassVar[dict[str, frozenset[str]]] = {}
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -39,9 +75,37 @@ class TemplatableBlock(Block):
         cls._templatable_fields = frozenset(templatable)
         cls._expression_fields = frozenset(expression)
 
+        step_templatable: dict[str, frozenset[str]] = {}
+        step_expression: dict[str, frozenset[str]] = {}
+        for attribute_name in dir(cls):
+            attribute = getattr(cls, attribute_name, None)
+            if not _issubclass(type(attribute), BlockFunction):
+                continue
+
+            t_params: set[str] = set()
+            e_params: set[str] = set()
+            for p_name, param in inspect.signature(attribute._fn).parameters.items():
+                if p_name == "self":
+                    continue
+                meta = getattr(param.annotation, "__metadata__", ())
+                if any(isinstance(m, Templatable) for m in meta):
+                    t_params.add(p_name)
+                if any(isinstance(m, Expression) for m in meta):
+                    e_params.add(p_name)
+
+            if t_params:
+                step_templatable[attribute_name] = frozenset(t_params)
+            if e_params:
+                step_expression[attribute_name] = frozenset(e_params)
+
+        cls._templatable_step_params = step_templatable
+        cls._expression_step_params = step_expression
+
     def __init__(self) -> None:
         super().__init__()
         self._raw_config: dict[str, Any] = {}
+        # (port, pin, pin_index) -> raw value, for @step parameters
+        self._raw_step_inputs: dict[tuple[str, str, str], Any] = {}
         self.context: dict[str, Any] = {}
 
     def _set_inputs(self, inputs: list) -> None:
@@ -53,6 +117,18 @@ class TemplatableBlock(Block):
             ) and field_name not in self._raw_config:
                 self._raw_config[field_name] = iv.value
 
+            port_name = iv.target.port.split(".")[0]
+            t_params = self._templatable_step_params.get(port_name, frozenset())
+            e_params = self._expression_step_params.get(port_name, frozenset())
+            if t_params or e_params:
+                pin_path = iv.target.pin.split(".")
+                pin_name = pin_path[0]
+                pin_index = pin_path[1] if len(pin_path) > 1 else ""
+                if pin_name in t_params or pin_name in e_params:
+                    key = (port_name, pin_name, pin_index)
+                    if key not in self._raw_step_inputs:
+                        self._raw_step_inputs[key] = iv.value
+
         super()._set_inputs(inputs)
 
         if self.context:
@@ -63,16 +139,20 @@ class TemplatableBlock(Block):
         import jmespath
         from smartspace.core import BlockError
 
-        if self._templatable_fields & self._raw_config.keys():
+        needs_env = bool(self._templatable_fields & self._raw_config.keys()) or any(
+            pin_name in self._templatable_step_params.get(port_name, frozenset())
+            for port_name, pin_name, _ in self._raw_step_inputs
+        )
+        if needs_env:
             env = make_jinja_env()
+            wrapped = {k: wrap_auto_json(v) for k, v in self.context.items()}
 
         for field_name in self._templatable_fields:
             raw = self._raw_config.get(field_name)
             if raw is None:
                 continue
-            wrapped = {k: wrap_auto_json(v) for k, v in self.context.items()}
             try:
-                rendered = env.from_string(raw).render(**wrapped)
+                rendered = _render_value(env, raw, wrapped)
             except Exception as e:
                 raise BlockError(f"Template rendering failed for '{field_name}': {e}")
             setattr(self, field_name, rendered)
@@ -88,3 +168,30 @@ class TemplatableBlock(Block):
                     f"Expression evaluation failed for '{field_name}': {e}"
                 )
             setattr(self, field_name, result)
+
+        # Step parameters: the engine has already stashed the raw value in the
+        # port's pending inputs (BlockFunction._pending_inputs); rewrite it in
+        # place so the step receives the rendered value when it runs.
+        for (port_name, pin_name, pin_index), raw in self._raw_step_inputs.items():
+            if raw is None:
+                continue
+
+            if pin_name in self._templatable_step_params.get(port_name, frozenset()):
+                try:
+                    value = _render_value(env, raw, wrapped)
+                except Exception as e:
+                    raise BlockError(
+                        f"Template rendering failed for '{port_name}.{pin_name}': {e}"
+                    )
+            else:
+                try:
+                    value = jmespath.search(raw, self.context)
+                except JMESPathError as e:
+                    raise BlockError(
+                        f"Expression evaluation failed for '{port_name}.{pin_name}': {e}"
+                    )
+
+            port = getattr(self, port_name)
+            if pin_name not in port._pending_inputs:
+                port._pending_inputs[pin_name] = {}
+            port._pending_inputs[pin_name][pin_index] = value

--- a/smartspace/core.py
+++ b/smartspace/core.py
@@ -134,6 +134,18 @@ def _get_function_pins(fn: Callable, port_name: str | None = None) -> FunctionPi
             {},
         )
 
+        # Mirror the class-attribute pin path: Templatable()/Expression() on a
+        # step parameter stamp the same metadata, so the designer renders the
+        # same code editor and TemplatableBlock knows to rewrite the pending
+        # value before the step runs.
+        if any(isinstance(m, Templatable) for m in annotations):
+            metadata = {**metadata, "templatable": True}
+            metadata.setdefault("language", InputLanguage.JINJA)
+
+        if any(isinstance(m, Expression) for m in annotations):
+            metadata = {**metadata, "expression": True}
+            metadata.setdefault("language", InputLanguage.JMESPATH)
+
         if param.default == inspect._empty:
             default = None
             required = True

--- a/smartspace/tests/test_templatable.py
+++ b/smartspace/tests/test_templatable.py
@@ -2,8 +2,9 @@ from typing import Annotated, Any
 
 import pytest
 
-from smartspace.core import BlockError, Config, Expression, Templatable
+from smartspace.core import BlockError, Config, Expression, Templatable, step
 from smartspace.blocks.templatable import TemplatableBlock
+from smartspace.enums import InputLanguage
 from smartspace.models import BlockPinRef, InputValue
 
 
@@ -179,3 +180,147 @@ def test_class_fields_cached_correctly():
     assert "prompt" not in SimpleTemplatable._expression_fields
     assert "condition" in SimpleExpression._expression_fields
     assert "condition" not in SimpleExpression._expression_fields or True  # expression only
+
+
+# ---------------------------------------------------------------------------
+# TemplatableBlock — @step parameters
+# ---------------------------------------------------------------------------
+
+
+class StepParamTemplatable(TemplatableBlock):
+    @step(output_name="out")
+    async def run(
+        self,
+        url: Annotated[str, Templatable()],
+        plain: str = "untouched",
+    ) -> str:
+        return url
+
+
+class StepParamExpression(TemplatableBlock):
+    @step(output_name="out")
+    async def run(self, picked: Annotated[Any, Expression()]) -> Any:
+        return picked
+
+
+class StepParamDict(TemplatableBlock):
+    @step(output_name="out")
+    async def run(
+        self, query_params: Annotated[dict[str, Any], Templatable()]
+    ) -> dict[str, Any]:
+        return query_params
+
+
+def test_step_params_cached_correctly():
+    assert StepParamTemplatable._templatable_step_params == {"run": frozenset({"url"})}
+    assert StepParamTemplatable._expression_step_params == {}
+    assert StepParamExpression._expression_step_params == {"run": frozenset({"picked"})}
+
+
+def test_step_param_interface_stamps_templatable_metadata():
+    pin = StepParamTemplatable.interface().ports["run"].inputs["url"]
+    assert pin.metadata["templatable"] is True
+    assert pin.metadata["language"] == InputLanguage.JINJA
+
+
+def test_step_param_interface_stamps_expression_metadata():
+    pin = StepParamExpression.interface().ports["run"].inputs["picked"]
+    assert pin.metadata["expression"] is True
+    assert pin.metadata["language"] == InputLanguage.JMESPATH
+
+
+def test_step_param_renders_when_context_set():
+    block = StepParamTemplatable()
+    block._set_inputs([
+        _iv("run", "url", "https://api.example.com/{{ path }}"),
+        _context_iv("path", "users/1"),
+    ])
+    assert block.run._pending_inputs["url"][""] == "https://api.example.com/users/1"
+
+
+def test_step_param_context_arriving_after_input():
+    block = StepParamTemplatable()
+    block._set_inputs([_iv("run", "url", "{{ base }}/items")])
+    assert block.run._pending_inputs["url"][""] == "{{ base }}/items"  # not yet
+
+    block._set_inputs([_context_iv("base", "https://api.example.com")])
+    assert block.run._pending_inputs["url"][""] == "https://api.example.com/items"
+
+
+def test_step_param_no_context_leaves_raw():
+    block = StepParamTemplatable()
+    block._set_inputs([_iv("run", "url", "{{ base }}/items")])
+    assert block.run._pending_inputs["url"][""] == "{{ base }}/items"
+
+
+def test_step_param_unmarked_param_untouched():
+    block = StepParamTemplatable()
+    block._set_inputs([
+        _iv("run", "url", "{{ base }}"),
+        _iv("run", "plain", "{{ base }}"),
+        _context_iv("base", "rendered"),
+    ])
+    assert block.run._pending_inputs["url"][""] == "rendered"
+    assert block.run._pending_inputs["plain"][""] == "{{ base }}"
+
+
+def test_step_param_render_error_names_port_and_pin():
+    block = StepParamTemplatable()
+    with pytest.raises(BlockError, match="run.url"):
+        block._set_inputs([
+            _iv("run", "url", "{{ typo }}"),
+            _context_iv("base", "x"),
+        ])
+
+
+def test_step_param_expression_evaluates():
+    block = StepParamExpression()
+    block._set_inputs([
+        _iv("run", "picked", "user.name"),
+        _context_iv("user", {"name": "Erin"}),
+    ])
+    assert block.run._pending_inputs["picked"][""] == "Erin"
+
+
+def test_step_param_dict_renders_string_leaves():
+    block = StepParamDict()
+    block._set_inputs([
+        _iv("run", "query_params", {"q": "{{ term }}", "page": 2, "tags": ["{{ tag }}", "fixed"]}),
+        _context_iv("term", "fishing"),
+        _context_iv("tag", "nz"),
+    ])
+    assert block.run._pending_inputs["query_params"][""] == {
+        "q": "fishing",
+        "page": 2,
+        "tags": ["nz", "fixed"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# TemplatableBlock — dict/list class-attribute fields
+# ---------------------------------------------------------------------------
+
+
+class DictConfigTemplatable(TemplatableBlock):
+    headers: Annotated[dict[str, Any], Config(), Templatable()] = {}
+
+
+def test_dict_config_renders_string_leaves():
+    block = DictConfigTemplatable()
+    block._set_inputs([
+        _iv("headers", "", {"Authorization": "Bearer {{ token }}", "Accept": "application/json"}),
+        _context_iv("token", "abc123"),
+    ])
+    assert block.headers == {
+        "Authorization": "Bearer abc123",
+        "Accept": "application/json",
+    }
+
+
+def test_dict_config_keys_not_rendered():
+    block = DictConfigTemplatable()
+    block._set_inputs([
+        _iv("headers", "", {"{{ key }}": "value"}),
+        _context_iv("key", "X-Real"),
+    ])
+    assert block.headers == {"{{ key }}": "value"}


### PR DESCRIPTION
## What

Extends the templating machinery so `Templatable()` / `Expression()` markers work on `@step` parameters, not just class-attribute pins, and so dict/list-typed Templatable pins render their string leaves.

- `_get_function_pins` stamps `templatable`/`expression` metadata + the `language` render hint on marked step parameters, mirroring the class-attribute path — the designer shows the same code editor on wired step pins.
- `TemplatableBlock` collects marked step parameters per port (`_templatable_step_params` / `_expression_step_params`) and rewrites the port's pending inputs after each `_set_inputs`, so steps receive rendered values.
- New `_render_value` recurses into dict/list values rendering string leaves (keys untouched) — header/query-param dicts can carry templates in their values. Applies to class-attribute fields too.

## Why

First consumer is an HTTP 4.0.0 block in Smartspace-ai-api (templateable URL + headers + query params with a variadic `context` port). Without this, templating only reaches class-attribute pins — a step parameter like `url` can't carry `{{ }}` even though it renders identically in the designer.

## Compatibility

- No existing block uses the markers on step params: the projected interfaces of **all 52 SDK blocks are byte-identical** before/after this change (verified by dumping and diffing both).
- Class-attribute behaviour unchanged, including the no-context passthrough (existing tests untouched and passing).
- Engine compatibility verified against ai-api dispatch: wired `context.*` pins are part of the required-or-wired gathering set, so steps can't fire before context arrives; values land via `_load → _set_inputs` in one batch, which is exactly the path the new tests exercise.

## Tests

13 new tests in `test_templatable.py` (metadata stamping, rendering, input-order independence, unmarked params untouched, dict leaves, error naming). Full suite: 111 passed.

## Follow-ups (not this PR)

- Designer: `gatherTemplateVariables` autocompletes from all wired inputs, but runtime resolves against `context` only — the editor may suggest identifiers that fail at runtime with StrictUndefined.
- ai-api: HTTP 4.0.0 block lands on `feat/http-templatable` once this merges (needs a lock repin).