### PR TITLE
Expression(): JMESPath inside {{ }}, uniform evaluation, always-evaluate

### DIFF
--- a/smartspace/blocks/templatable.py
+++ b/smartspace/blocks/templatable.py
@@ -13,6 +13,14 @@ from smartspace.core import (
 from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
 from smartspace.utils.utils import _issubclass
 
+# Appended to expression errors: mistaking literal text for an expression is
+# the overwhelmingly common first mistake, and the raw JMESPath lexer error
+# ("Unknown token /") doesn't hint at the fix.
+_EXPRESSION_HINT = (
+    "Values are JMESPath expressions, so literal text needs single quotes "
+    "(e.g. 'application/json') and bare names must match a wired context input."
+)
+
 
 def _eval_expression(raw: Any, context: dict[str, Any]) -> Any:
     """Evaluate an Expression value against the context.
@@ -207,7 +215,8 @@ class TemplatableBlock(Block):
                 result = _eval_expression(raw, self.context)
             except JMESPathError as e:
                 raise BlockError(
-                    f"Expression evaluation failed for '{field_name}': {e}"
+                    f"Expression evaluation failed for '{field_name}': {e}. "
+                    f"{_EXPRESSION_HINT}"
                 )
             setattr(self, field_name, result)
 
@@ -230,7 +239,8 @@ class TemplatableBlock(Block):
                     value = _eval_expression(raw, self.context)
                 except JMESPathError as e:
                     raise BlockError(
-                        f"Expression evaluation failed for '{port_name}.{pin_name}': {e}"
+                        f"Expression evaluation failed for '{port_name}.{pin_name}': "
+                        f"{e}. {_EXPRESSION_HINT}"
                     )
 
             port = getattr(self, port_name)

--- a/smartspace/blocks/templatable.py
+++ b/smartspace/blocks/templatable.py
@@ -1,4 +1,6 @@
 import inspect
+import json
+import re
 from typing import Annotated, Any, ClassVar
 
 import jmespath
@@ -13,31 +15,73 @@ from smartspace.core import (
 from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
 from smartspace.utils.utils import _issubclass
 
-# Appended to expression errors: mistaking literal text for an expression is
-# the overwhelmingly common first mistake, and the raw JMESPath lexer error
-# ("Unknown token /") doesn't hint at the fix.
 _EXPRESSION_HINT = (
-    "Values are JMESPath expressions, so literal text needs single quotes "
-    "(e.g. 'application/json') and bare names must match a wired context input."
+    "JMESPath expressions go inside {{ }} and resolve against the wired "
+    "context inputs; text outside {{ }} is literal."
 )
+
+# Non-greedy so adjacent expressions in one string don't merge into one match.
+_EXPRESSION_PATTERN = re.compile(r"\{\{(.*?)\}\}", re.DOTALL)
+# A leaf that is nothing but one expression, so its typed result can be spliced
+# in whole rather than stringified into surrounding text.
+_WHOLE_EXPRESSION_PATTERN = re.compile(r"\s*\{\{(.*?)\}\}\s*", re.DOTALL)
+
+
+class ExpressionError(Exception):
+    """An expression was malformed or produced an unusable value."""
+
+
+def _stringify(value: Any) -> str:
+    """Render an expression result for interpolation into surrounding text."""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+def _eval_expression_string(raw: str, context: dict[str, Any]) -> Any:
+    whole = _WHOLE_EXPRESSION_PATTERN.fullmatch(raw)
+    if whole:
+        expression = whole.group(1).strip()
+        if not expression:
+            raise ExpressionError("Empty expression: {{ }}")
+        return jmespath.search(expression, context)
+
+    def _replace(match: "re.Match[str]") -> str:
+        expression = match.group(1).strip()
+        if not expression:
+            raise ExpressionError("Empty expression: {{ }}")
+        value = jmespath.search(expression, context)
+        if value is None:
+            # Interpolating null into surrounding text is nearly always a
+            # mistake (a typo, or an input that was never wired) and would
+            # otherwise silently produce "Bearer null".
+            raise ExpressionError(
+                f"{{{{ {expression} }}}} evaluated to null in {raw!r}"
+            )
+        return _stringify(value)
+
+    return _EXPRESSION_PATTERN.sub(_replace, raw)
 
 
 def _eval_expression(raw: Any, context: dict[str, Any]) -> Any:
     """Evaluate an Expression value against the context.
 
-    Uniform and provenance-free: whatever arrives at an Expression() pin is an
-    expression, whether it was typed into the designer or wired in from
-    upstream. Strings are evaluated as JMESPath. Dicts and lists are walked and
-    their string leaves evaluated, so an object-shaped pin (e.g. HTTP headers)
-    is an expression object. Dict keys are never evaluated. Numbers, booleans
-    and None can't be expressions and pass through.
+    JMESPath expressions are delimited by ``{{ }}``; text outside them is
+    literal. A leaf that is *only* an expression splices its result in with
+    the type intact (``"{{ length(items) }}"`` -> ``3``); an expression
+    embedded in text stringifies into place (``"Bearer {{ apiKey }}"``).
 
-    Note this means literal text needs JMESPath's raw-string quoting —
-    `'application/json'`, not `application/json`. To pass computed data
-    through untouched, wire it into a `context` pin and reference it by name.
+    Evaluation is uniform and provenance-free: a value typed into the designer
+    and a value wired in from upstream are treated identically. Dicts and
+    lists are walked so an object-shaped pin is an expression object; dict keys
+    are never evaluated, and non-string scalars pass through.
+
+    Because only ``{{ }}`` is an expression, data that contains no braces
+    passes through untouched — wiring a computed payload into an Expression
+    pin is safe.
     """
     if isinstance(raw, str):
-        return jmespath.search(raw, context)
+        return _eval_expression_string(raw, context)
     if isinstance(raw, dict):
         return {k: _eval_expression(v, context) for k, v in raw.items()}
     if isinstance(raw, list):
@@ -75,13 +119,13 @@ class TemplatableBlock(Block):
     rendered, so e.g. header or query-param dicts can carry templates in
     their values.
 
-    Expression() pins are evaluated uniformly regardless of where the value
-    came from: a value typed into the designer and a value wired in from
-    upstream are both expressions. Objects and lists are walked and their
-    string leaves evaluated, so an object-shaped pin is an expression object.
-    Literal text therefore needs JMESPath raw-string quoting
-    ('application/json'); to pass computed data through untouched, wire it
-    into a `context` pin and reference it by name.
+    Expression() pins hold JMESPath inside `{{ }}`; text outside is literal.
+    Evaluation is uniform regardless of where the value came from — typed into
+    the designer or wired in from upstream — and objects and lists are walked,
+    so an object-shaped pin is an expression object. A leaf that is only an
+    expression keeps its type ("{{ length(items) }}" -> 3); one embedded in
+    text stringifies ("Bearer {{ apiKey }}"). Data containing no braces passes
+    through untouched.
 
     Evaluation always runs, context or not: literal-only templates work with
     nothing wired, expressions evaluate against an empty document (missing
@@ -213,7 +257,7 @@ class TemplatableBlock(Block):
                 continue
             try:
                 result = _eval_expression(raw, self.context)
-            except JMESPathError as e:
+            except (JMESPathError, ExpressionError) as e:
                 raise BlockError(
                     f"Expression evaluation failed for '{field_name}': {e}. "
                     f"{_EXPRESSION_HINT}"
@@ -237,7 +281,7 @@ class TemplatableBlock(Block):
             else:
                 try:
                     value = _eval_expression(raw, self.context)
-                except JMESPathError as e:
+                except (JMESPathError, ExpressionError) as e:
                     raise BlockError(
                         f"Expression evaluation failed for '{port_name}.{pin_name}': "
                         f"{e}. {_EXPRESSION_HINT}"

--- a/smartspace/blocks/templatable.py
+++ b/smartspace/blocks/templatable.py
@@ -1,6 +1,8 @@
 import inspect
 from typing import Annotated, Any, ClassVar
 
+import jmespath
+
 from smartspace.core import (
     Block,
     BlockFunction,
@@ -10,6 +12,29 @@ from smartspace.core import (
 )
 from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
 from smartspace.utils.utils import _issubclass
+
+
+def _eval_expression(raw: Any, context: dict[str, Any]) -> Any:
+    """Evaluate an Expression value against the context.
+
+    Uniform and provenance-free: whatever arrives at an Expression() pin is an
+    expression, whether it was typed into the designer or wired in from
+    upstream. Strings are evaluated as JMESPath. Dicts and lists are walked and
+    their string leaves evaluated, so an object-shaped pin (e.g. HTTP headers)
+    is an expression object. Dict keys are never evaluated. Numbers, booleans
+    and None can't be expressions and pass through.
+
+    Note this means literal text needs JMESPath's raw-string quoting —
+    `'application/json'`, not `application/json`. To pass computed data
+    through untouched, wire it into a `context` pin and reference it by name.
+    """
+    if isinstance(raw, str):
+        return jmespath.search(raw, context)
+    if isinstance(raw, dict):
+        return {k: _eval_expression(v, context) for k, v in raw.items()}
+    if isinstance(raw, list):
+        return [_eval_expression(v, context) for v in raw]
+    return raw
 
 
 def _render_value(env: Any, raw: Any, wrapped_context: dict[str, Any]) -> Any:
@@ -42,8 +67,14 @@ class TemplatableBlock(Block):
     rendered, so e.g. header or query-param dicts can carry templates in
     their values.
 
-    Expression() pins only treat *strings* as expressions — any other value
-    (e.g. an object wired straight into the pin) passes through as data.
+    Expression() pins are evaluated uniformly regardless of where the value
+    came from: a value typed into the designer and a value wired in from
+    upstream are both expressions. Objects and lists are walked and their
+    string leaves evaluated, so an object-shaped pin is an expression object.
+    Literal text therefore needs JMESPath raw-string quoting
+    ('application/json'); to pass computed data through untouched, wire it
+    into a `context` pin and reference it by name.
+
     Evaluation always runs, context or not: literal-only templates work with
     nothing wired, expressions evaluate against an empty document (missing
     references become null), and a Jinja template referencing an unwired
@@ -172,13 +203,8 @@ class TemplatableBlock(Block):
             raw = self._raw_config.get(field_name)
             if raw is None:
                 continue
-            # Only strings are expressions. A non-string value (e.g. an object
-            # wired straight into the pin) is data, not an expression — leave
-            # the delivered value in place untouched.
-            if not isinstance(raw, str):
-                continue
             try:
-                result = jmespath.search(raw, self.context)
+                result = _eval_expression(raw, self.context)
             except JMESPathError as e:
                 raise BlockError(
                     f"Expression evaluation failed for '{field_name}': {e}"
@@ -200,12 +226,8 @@ class TemplatableBlock(Block):
                         f"Template rendering failed for '{port_name}.{pin_name}': {e}"
                     )
             else:
-                # Only strings are expressions — non-string values (e.g. an
-                # object wired straight into the pin) pass through as data.
-                if not isinstance(raw, str):
-                    continue
                 try:
-                    value = jmespath.search(raw, self.context)
+                    value = _eval_expression(raw, self.context)
                 except JMESPathError as e:
                     raise BlockError(
                         f"Expression evaluation failed for '{port_name}.{pin_name}': {e}"

--- a/smartspace/blocks/templatable.py
+++ b/smartspace/blocks/templatable.py
@@ -42,6 +42,13 @@ class TemplatableBlock(Block):
     rendered, so e.g. header or query-param dicts can carry templates in
     their values.
 
+    Expression() pins only treat *strings* as expressions — any other value
+    (e.g. an object wired straight into the pin) passes through as data.
+    Evaluation always runs, context or not: literal-only templates work with
+    nothing wired, expressions evaluate against an empty document (missing
+    references become null), and a Jinja template referencing an unwired
+    context input raises (StrictUndefined) rather than leaking "{{ }}".
+
     Example:
         class MyBlock(TemplatableBlock):
             prompt: Annotated[str | None, Config(), Templatable()] = None
@@ -131,8 +138,12 @@ class TemplatableBlock(Block):
 
         super()._set_inputs(inputs)
 
-        if self.context:
-            self._apply_templates()
+        # Always apply — a template/expression may be entirely literal (no
+        # context references), so an empty context must not skip evaluation.
+        # The engine delivers all of a run's inputs in a single batch, so a
+        # Jinja template referencing an unwired context input fails loudly
+        # here (StrictUndefined) instead of leaking "{{ }}" downstream.
+        self._apply_templates()
 
     def _apply_templates(self) -> None:
         from jmespath.exceptions import JMESPathError
@@ -161,6 +172,11 @@ class TemplatableBlock(Block):
             raw = self._raw_config.get(field_name)
             if raw is None:
                 continue
+            # Only strings are expressions. A non-string value (e.g. an object
+            # wired straight into the pin) is data, not an expression — leave
+            # the delivered value in place untouched.
+            if not isinstance(raw, str):
+                continue
             try:
                 result = jmespath.search(raw, self.context)
             except JMESPathError as e:
@@ -184,6 +200,10 @@ class TemplatableBlock(Block):
                         f"Template rendering failed for '{port_name}.{pin_name}': {e}"
                     )
             else:
+                # Only strings are expressions — non-string values (e.g. an
+                # object wired straight into the pin) pass through as data.
+                if not isinstance(raw, str):
+                    continue
                 try:
                     value = jmespath.search(raw, self.context)
                 except JMESPathError as e:

--- a/smartspace/tests/test_templatable.py
+++ b/smartspace/tests/test_templatable.py
@@ -130,7 +130,7 @@ def test_templatable_autojson_full_object_serialises():
 def test_expression_evaluates_jmespath():
     block = SimpleExpression()
     block._set_inputs([
-        _iv("condition", "", "user.active"),
+        _iv("condition", "", "{{ user.active }}"),
         _context_iv("user", {"active": True}),
     ])
     assert block.condition is True
@@ -139,7 +139,7 @@ def test_expression_evaluates_jmespath():
 def test_expression_returns_typed_value():
     block = SimpleExpression()
     block._set_inputs([
-        _iv("condition", "", "length(items)"),
+        _iv("condition", "", "{{ length(items) }}"),
         _context_iv("items", [1, 2, 3]),
     ])
     assert block.condition == 3
@@ -149,7 +149,7 @@ def test_expression_invalid_raises_block_error():
     block = SimpleExpression()
     with pytest.raises(BlockError, match="Expression evaluation failed"):
         block._set_inputs([
-            _iv("condition", "", "!!!invalid!!!"),
+            _iv("condition", "", "{{ !!!invalid!!! }}"),
             _context_iv("x", 1),
         ])
 
@@ -162,7 +162,7 @@ def test_both_markers_render_independently():
     block = BothMarkers()
     block._set_inputs([
         _iv("prompt", "", "Hello {{ name }}"),
-        _iv("condition", "", "score"),
+        _iv("condition", "", "{{ score }}"),
         _context_iv("name", "Dave"),
         _context_iv("score", 42),
     ])
@@ -279,7 +279,7 @@ def test_step_param_render_error_names_port_and_pin():
 def test_step_param_expression_evaluates():
     block = StepParamExpression()
     block._set_inputs([
-        _iv("run", "picked", "user.name"),
+        _iv("run", "picked", "{{ user.name }}"),
         _context_iv("user", {"name": "Erin"}),
     ])
     assert block.run._pending_inputs["picked"][""] == "Erin"
@@ -290,7 +290,7 @@ def test_step_param_expression_object_is_evaluated():
     # wired object is an expression object, its string leaves evaluated.
     block = StepParamExpression()
     block._set_inputs([
-        _iv("run", "picked", {"name": "user.name", "kind": "'literal'"}),
+        _iv("run", "picked", {"name": "{{ user.name }}", "kind": "literal"}),
         _context_iv("user", {"name": "Erin"}),
     ])
     assert block.run._pending_inputs["picked"][""] == {
@@ -302,7 +302,7 @@ def test_step_param_expression_object_is_evaluated():
 def test_step_param_expression_nested_list_evaluated():
     block = StepParamExpression()
     block._set_inputs([
-        _iv("run", "picked", {"ids": ["items[0].id", "items[1].id"], "n": 3}),
+        _iv("run", "picked", {"ids": ["{{ items[0].id }}", "{{ items[1].id }}"], "n": 3}),
         _context_iv("items", [{"id": "a"}, {"id": "b"}]),
     ])
     # Non-string scalars can't be expressions and pass through
@@ -312,44 +312,98 @@ def test_step_param_expression_nested_list_evaluated():
 def test_step_param_expression_dict_keys_not_evaluated():
     block = StepParamExpression()
     block._set_inputs([
-        _iv("run", "picked", {"user": "'x'"}),
+        _iv("run", "picked", {"user": "x"}),
         _context_iv("user", {"name": "Erin"}),
     ])
     assert block.run._pending_inputs["picked"][""] == {"user": "x"}
 
 
-def test_step_param_expression_quoted_literal_is_itself():
-    # JMESPath raw string literals are the escape hatch for literal text
-    # payloads: 'query { things }' evaluates to itself.
+def test_step_param_expression_literal_text_needs_no_quoting():
+    # Text outside {{ }} is never parsed, so literal payloads (GraphQL, XML)
+    # pass through as written.
     block = StepParamExpression()
-    block._set_inputs([_iv("run", "picked", "'query { things }'")])
+    block._set_inputs([_iv("run", "picked", "query { things }")])
     assert block.run._pending_inputs["picked"][""] == "query { things }"
+
+
+def test_step_param_expression_interpolates_into_text():
+    block = StepParamExpression()
+    block._set_inputs([
+        _iv("run", "picked", "Bearer {{ apiKey }}"),
+        _context_iv("apiKey", "tok-123"),
+    ])
+    assert block.run._pending_inputs["picked"][""] == "Bearer tok-123"
+
+
+def test_step_param_expression_whole_value_keeps_type():
+    block = StepParamExpression()
+    block._set_inputs([
+        _iv("run", "picked", "{{ length(items) }}"),
+        _context_iv("items", [1, 2, 3]),
+    ])
+    value = block.run._pending_inputs["picked"][""]
+    assert value == 3 and isinstance(value, int)
+
+
+def test_step_param_expression_embedded_stringifies():
+    block = StepParamExpression()
+    block._set_inputs([
+        _iv("run", "picked", "count={{ length(items) }} obj={{ user }}"),
+        _context_iv("items", [1, 2]),
+        _context_iv("user", {"a": 1}),
+    ])
+    assert block.run._pending_inputs["picked"][""] == 'count=2 obj={"a": 1}'
+
+
+def test_step_param_expression_wired_data_passes_through():
+    # The case that made us choose {{ }}: real data has no braces, so an
+    # upstream payload wired into an Expression pin is untouched.
+    block = StepParamExpression()
+    payload = {"name": "Alice", "role": "admin", "age": 30}
+    block._set_inputs([
+        _iv("run", "picked", payload),
+        _context_iv("user", {"name": "someone else"}),
+    ])
+    assert block.run._pending_inputs["picked"][""] == payload
+
+
+def test_step_param_expression_embedded_null_raises():
+    # "Bearer null" is never what anyone meant.
+    block = StepParamExpression()
+    with pytest.raises(BlockError, match="evaluated to null"):
+        block._set_inputs([_iv("run", "picked", "Bearer {{ apiKey }}")])
+
+
+def test_step_param_expression_empty_braces_raise():
+    block = StepParamExpression()
+    with pytest.raises(BlockError, match="Empty expression"):
+        block._set_inputs([_iv("run", "picked", "{{ }}")])
 
 
 def test_step_param_expression_empty_context_missing_ref_is_null():
     block = StepParamExpression()
-    block._set_inputs([_iv("run", "picked", "user.name")])
+    block._set_inputs([_iv("run", "picked", "{{ user.name }}")])
     assert block.run._pending_inputs["picked"][""] is None
 
 
 def test_expression_class_attr_object_is_evaluated():
     block = SimpleExpression()
     block._set_inputs([
-        _iv("condition", "", {"a": "x", "b": "'lit'", "c": True}),
+        _iv("condition", "", {"a": "{{ x }}", "b": "lit", "c": True}),
         _context_iv("x", 1),
     ])
     assert block.condition == {"a": 1, "b": "lit", "c": True}
 
 
 def test_expression_headers_shape_end_to_end():
-    # The motivating case: an expression object mixing a literal, an
-    # interpolation-by-join, and a computed value.
+    # The motivating case: an expression object mixing a plain literal, an
+    # interpolation, and a computed value that keeps its type.
     block = SimpleExpression()
     block._set_inputs([
         _iv("condition", "", {
-            "Content-Type": "'application/json'",
-            "Authorization": "join(' ', ['Bearer', apiKey])",
-            "X-Count": "length(items)",
+            "Content-Type": "application/json",
+            "Authorization": "Bearer {{ apiKey }}",
+            "X-Count": "{{ length(items) }}",
         }),
         _context_iv("apiKey", "tok-123"),
         _context_iv("items", [1, 2, 3]),

--- a/smartspace/tests/test_templatable.py
+++ b/smartspace/tests/test_templatable.py
@@ -42,15 +42,6 @@ def test_templatable_renders_when_context_set():
     assert block.prompt == "Hello World!"
 
 
-def test_templatable_context_arriving_after_config():
-    block = SimpleTemplatable()
-    block._set_inputs([_iv("prompt", "", "Hello {{ name }}!")])
-    assert block.prompt == "Hello {{ name }}!"  # not yet rendered
-
-    block._set_inputs([_context_iv("name", "Alice")])
-    assert block.prompt == "Hello Alice!"
-
-
 def test_templatable_config_arriving_after_context():
     block = SimpleTemplatable()
     block._set_inputs([_context_iv("name", "Bob")])
@@ -58,10 +49,18 @@ def test_templatable_config_arriving_after_context():
     assert block.prompt == "Hello Bob!"
 
 
-def test_templatable_no_context_leaves_raw():
+def test_templatable_literal_renders_without_context():
     block = SimpleTemplatable()
-    block._set_inputs([_iv("prompt", "", "Hello {{ name }}!")])
-    assert block.prompt == "Hello {{ name }}!"
+    block._set_inputs([_iv("prompt", "", "Hello, no variables here.")])
+    assert block.prompt == "Hello, no variables here."
+
+
+def test_templatable_unwired_reference_raises():
+    # The engine delivers a run's inputs in one batch, so a template that
+    # references an unwired context input must fail loudly, not pass through.
+    block = SimpleTemplatable()
+    with pytest.raises(BlockError, match="Template rendering failed"):
+        block._set_inputs([_iv("prompt", "", "Hello {{ name }}!")])
 
 
 def test_templatable_none_value_skipped():
@@ -238,19 +237,23 @@ def test_step_param_renders_when_context_set():
     assert block.run._pending_inputs["url"][""] == "https://api.example.com/users/1"
 
 
-def test_step_param_context_arriving_after_input():
+def test_step_param_context_arriving_first():
     block = StepParamTemplatable()
-    block._set_inputs([_iv("run", "url", "{{ base }}/items")])
-    assert block.run._pending_inputs["url"][""] == "{{ base }}/items"  # not yet
-
     block._set_inputs([_context_iv("base", "https://api.example.com")])
+    block._set_inputs([_iv("run", "url", "{{ base }}/items")])
     assert block.run._pending_inputs["url"][""] == "https://api.example.com/items"
 
 
-def test_step_param_no_context_leaves_raw():
+def test_step_param_literal_passes_without_context():
     block = StepParamTemplatable()
-    block._set_inputs([_iv("run", "url", "{{ base }}/items")])
-    assert block.run._pending_inputs["url"][""] == "{{ base }}/items"
+    block._set_inputs([_iv("run", "url", "https://api.example.com/items")])
+    assert block.run._pending_inputs["url"][""] == "https://api.example.com/items"
+
+
+def test_step_param_unwired_reference_raises():
+    block = StepParamTemplatable()
+    with pytest.raises(BlockError, match="run.url"):
+        block._set_inputs([_iv("run", "url", "{{ base }}/items")])
 
 
 def test_step_param_unmarked_param_untouched():
@@ -280,6 +283,41 @@ def test_step_param_expression_evaluates():
         _context_iv("user", {"name": "Erin"}),
     ])
     assert block.run._pending_inputs["picked"][""] == "Erin"
+
+
+def test_step_param_expression_non_string_passes_through():
+    # A wired object is data, not an expression — e.g. a dict piped into an
+    # Expression()-marked body pin must arrive untouched.
+    block = StepParamExpression()
+    payload = {"name": "Erin", "tags": ["a", "b"]}
+    block._set_inputs([
+        _iv("run", "picked", payload),
+        _context_iv("user", {"name": "X"}),
+    ])
+    assert block.run._pending_inputs["picked"][""] == payload
+
+
+def test_step_param_expression_quoted_literal_is_itself():
+    # JMESPath raw string literals are the escape hatch for literal text
+    # payloads: 'query { things }' evaluates to itself.
+    block = StepParamExpression()
+    block._set_inputs([_iv("run", "picked", "'query { things }'")])
+    assert block.run._pending_inputs["picked"][""] == "query { things }"
+
+
+def test_step_param_expression_empty_context_missing_ref_is_null():
+    block = StepParamExpression()
+    block._set_inputs([_iv("run", "picked", "user.name")])
+    assert block.run._pending_inputs["picked"][""] is None
+
+
+def test_expression_class_attr_non_string_passes_through():
+    block = SimpleExpression()
+    block._set_inputs([
+        _iv("condition", "", {"already": "data"}),
+        _context_iv("x", 1),
+    ])
+    assert block.condition == {"already": "data"}
 
 
 def test_step_param_dict_renders_string_leaves():

--- a/smartspace/tests/test_templatable.py
+++ b/smartspace/tests/test_templatable.py
@@ -285,16 +285,37 @@ def test_step_param_expression_evaluates():
     assert block.run._pending_inputs["picked"][""] == "Erin"
 
 
-def test_step_param_expression_non_string_passes_through():
-    # A wired object is data, not an expression — e.g. a dict piped into an
-    # Expression()-marked body pin must arrive untouched.
+def test_step_param_expression_object_is_evaluated():
+    # An Expression pin holds an expression wherever the value came from: a
+    # wired object is an expression object, its string leaves evaluated.
     block = StepParamExpression()
-    payload = {"name": "Erin", "tags": ["a", "b"]}
     block._set_inputs([
-        _iv("run", "picked", payload),
-        _context_iv("user", {"name": "X"}),
+        _iv("run", "picked", {"name": "user.name", "kind": "'literal'"}),
+        _context_iv("user", {"name": "Erin"}),
     ])
-    assert block.run._pending_inputs["picked"][""] == payload
+    assert block.run._pending_inputs["picked"][""] == {
+        "name": "Erin",
+        "kind": "literal",
+    }
+
+
+def test_step_param_expression_nested_list_evaluated():
+    block = StepParamExpression()
+    block._set_inputs([
+        _iv("run", "picked", {"ids": ["items[0].id", "items[1].id"], "n": 3}),
+        _context_iv("items", [{"id": "a"}, {"id": "b"}]),
+    ])
+    # Non-string scalars can't be expressions and pass through
+    assert block.run._pending_inputs["picked"][""] == {"ids": ["a", "b"], "n": 3}
+
+
+def test_step_param_expression_dict_keys_not_evaluated():
+    block = StepParamExpression()
+    block._set_inputs([
+        _iv("run", "picked", {"user": "'x'"}),
+        _context_iv("user", {"name": "Erin"}),
+    ])
+    assert block.run._pending_inputs["picked"][""] == {"user": "x"}
 
 
 def test_step_param_expression_quoted_literal_is_itself():
@@ -311,13 +332,33 @@ def test_step_param_expression_empty_context_missing_ref_is_null():
     assert block.run._pending_inputs["picked"][""] is None
 
 
-def test_expression_class_attr_non_string_passes_through():
+def test_expression_class_attr_object_is_evaluated():
     block = SimpleExpression()
     block._set_inputs([
-        _iv("condition", "", {"already": "data"}),
+        _iv("condition", "", {"a": "x", "b": "'lit'", "c": True}),
         _context_iv("x", 1),
     ])
-    assert block.condition == {"already": "data"}
+    assert block.condition == {"a": 1, "b": "lit", "c": True}
+
+
+def test_expression_headers_shape_end_to_end():
+    # The motivating case: an expression object mixing a literal, an
+    # interpolation-by-join, and a computed value.
+    block = SimpleExpression()
+    block._set_inputs([
+        _iv("condition", "", {
+            "Content-Type": "'application/json'",
+            "Authorization": "join(' ', ['Bearer', apiKey])",
+            "X-Count": "length(items)",
+        }),
+        _context_iv("apiKey", "tok-123"),
+        _context_iv("items", [1, 2, 3]),
+    ])
+    assert block.condition == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer tok-123",
+        "X-Count": 3,
+    }
 
 
 def test_step_param_dict_renders_string_leaves():


### PR DESCRIPTION
Follow-up to #289, driven by the first real consumer (HTTP 4.0.0 block in ai-api).

## Changes

**1. Expression() pins hold JMESPath inside `{{ }}`; text outside is literal.**

```json
{
  "Content-Type":  "application/json",        // literal — never parsed
  "Authorization": "Bearer {{ apiKey }}",     // interpolated into the text
  "X-Count":       "{{ length(items) }}"      // whole value — stays a number
}
```

A leaf that is *only* an expression splices its result in with the type intact; one embedded in text stringifies into place (objects/arrays as JSON). Interpolating a null raises rather than emitting `"Bearer null"`.

**2. Evaluation is uniform and provenance-free.** A value typed into the designer and a value wired in from upstream are treated identically, and objects/lists are walked so an object-shaped pin is an expression object. Dict keys and non-string scalars are left alone.

The `{{ }}` delimiter is what makes that safe. Inferring expressions from the *type* of the value silently corrupted wired data — a payload `{"name": "Alice"}` evaluated `Alice` as an identifier and produced `{"name": null}` with no error. Real data contains no braces, so it now passes through untouched. It also removes the raw-string quoting burden, so literal GraphQL/XML payloads work as written.

**3. Evaluation is no longer gated on a non-empty context.** The old `if self.context:` skip meant a literal-only value was never evaluated and leaked the raw string downstream. Now literals resolve with nothing wired, and a Jinja template referencing an unwired context input raises StrictUndefined instead of sending `{{ }}` out the wire. Safe because the engine delivers a run's inputs in a single `_load → _set_inputs` batch per block instance.

## Tests

Suite: 125 passed. New coverage for interpolation, type-preserving whole-value splice, wired-data passthrough, nested objects/lists, keys-not-evaluated, embedded-null, and empty braces.

Still no production consumers of TemplatableBlock on develop, so this changes no live block.