### PR TITLE
Expression() is a whole-value JMESPath expression, matching Transform

### DIFF
--- a/smartspace/blocks/templatable.py
+++ b/smartspace/blocks/templatable.py
@@ -1,6 +1,4 @@
 import inspect
-import json
-import re
 from typing import Annotated, Any, ClassVar
 
 import jmespath
@@ -16,77 +14,35 @@ from smartspace.blocks._template_utils import make_jinja_env, wrap_auto_json
 from smartspace.utils.utils import _issubclass
 
 _EXPRESSION_HINT = (
-    "JMESPath expressions go inside {{ }} and resolve against the wired "
-    "context inputs; text outside {{ }} is literal."
+    "The whole pin value is one JMESPath expression, evaluated against the "
+    "wired context inputs — the same contract as the Transform block. Object "
+    "keys containing a hyphen must be double-quoted (\"Content-Type\"), while "
+    "literal text values take single quotes ('application/json') — double "
+    "quotes there are a field lookup. There is no {{ }} interpolation; "
+    "concatenate with join('', ['Bearer ', apiToken])."
 )
-
-# Non-greedy so adjacent expressions in one string don't merge into one match.
-_EXPRESSION_PATTERN = re.compile(r"\{\{(.*?)\}\}", re.DOTALL)
-# A leaf that is nothing but one expression, so its typed result can be spliced
-# in whole rather than stringified into surrounding text.
-_WHOLE_EXPRESSION_PATTERN = re.compile(r"\s*\{\{(.*?)\}\}\s*", re.DOTALL)
-
-
-class ExpressionError(Exception):
-    """An expression was malformed or produced an unusable value."""
-
-
-def _stringify(value: Any) -> str:
-    """Render an expression result for interpolation into surrounding text."""
-    if isinstance(value, str):
-        return value
-    return json.dumps(value)
-
-
-def _eval_expression_string(raw: str, context: dict[str, Any]) -> Any:
-    whole = _WHOLE_EXPRESSION_PATTERN.fullmatch(raw)
-    if whole:
-        expression = whole.group(1).strip()
-        if not expression:
-            raise ExpressionError("Empty expression: {{ }}")
-        return jmespath.search(expression, context)
-
-    def _replace(match: "re.Match[str]") -> str:
-        expression = match.group(1).strip()
-        if not expression:
-            raise ExpressionError("Empty expression: {{ }}")
-        value = jmespath.search(expression, context)
-        if value is None:
-            # Interpolating null into surrounding text is nearly always a
-            # mistake (a typo, or an input that was never wired) and would
-            # otherwise silently produce "Bearer null".
-            raise ExpressionError(
-                f"{{{{ {expression} }}}} evaluated to null in {raw!r}"
-            )
-        return _stringify(value)
-
-    return _EXPRESSION_PATTERN.sub(_replace, raw)
 
 
 def _eval_expression(raw: Any, context: dict[str, Any]) -> Any:
     """Evaluate an Expression value against the context.
 
-    JMESPath expressions are delimited by ``{{ }}``; text outside them is
-    literal. A leaf that is *only* an expression splices its result in with
-    the type intact (``"{{ length(items) }}"`` -> ``3``); an expression
-    embedded in text stringifies into place (``"Bearer {{ apiKey }}"``).
+    The whole pin value is one JMESPath expression, evaluated against a
+    document whose keys are the connected context inputs. This is the same
+    contract as the Transform block, and results keep their JSON type — an
+    expression that builds an object yields an object, not text.
 
-    Evaluation is uniform and provenance-free: a value typed into the designer
-    and a value wired in from upstream are treated identically. Dicts and
-    lists are walked so an object-shaped pin is an expression object; dict keys
-    are never evaluated, and non-string scalars pass through.
+    A non-string value was wired in from upstream rather than typed into the
+    designer, so it is already the data and passes through untouched. That
+    keeps a computed payload safe to wire into an Expression pin.
 
-    Because only ``{{ }}`` is an expression, data that contains no braces
-    passes through untouched — wiring a computed payload into an Expression
-    pin is safe.
+    There is deliberately no ``{{ }}`` interpolation here. Interpolation
+    produces text by construction, which defeats the point of a typed
+    expression pin; pins that are genuinely text (a URL, a prompt) use
+    Templatable() and Jinja instead.
     """
-    if isinstance(raw, str):
-        return _eval_expression_string(raw, context)
-    if isinstance(raw, dict):
-        return {k: _eval_expression(v, context) for k, v in raw.items()}
-    if isinstance(raw, list):
-        return [_eval_expression(v, context) for v in raw]
-    return raw
+    if not isinstance(raw, str):
+        return raw
+    return jmespath.compile(raw).search(context)
 
 
 def _render_value(env: Any, raw: Any, wrapped_context: dict[str, Any]) -> Any:
@@ -110,22 +66,24 @@ class TemplatableBlock(Block):
     """Base class for blocks that want Jinja2 or JMESPath evaluation applied to
     input pins before each step runs.
 
-    Mark string pins with Templatable() for Jinja2 rendering or Expression()
-    for JMESPath evaluation. Both work on class-attribute pins (Config or
-    Input) and on @step parameters, and resolve against the variadic named
-    `context` port — each connected input becomes a top-level key.
+    Mark pins with Templatable() for Jinja2 rendering or Expression() for
+    JMESPath evaluation. Both work on class-attribute pins (Config or Input)
+    and on @step parameters, and resolve against the variadic named `context`
+    port — each connected input becomes a top-level key. The marker is the
+    whole declaration: it also stamps the pin's editor language for the flow
+    designer, so a block never hand-writes Metadata(language=...) or evaluates
+    for itself.
 
-    Dict- and list-typed Templatable pins are walked and their string leaves
-    rendered, so e.g. header or query-param dicts can carry templates in
-    their values.
+    The two markers split on what the pin holds. TEXT pins — a URL, a prompt —
+    take Templatable(): literal text with {{ }} substitutions, rendering to
+    text by definition. Dict- and list-typed Templatable pins are walked and
+    their string leaves rendered.
 
-    Expression() pins hold JMESPath inside `{{ }}`; text outside is literal.
-    Evaluation is uniform regardless of where the value came from — typed into
-    the designer or wired in from upstream — and objects and lists are walked,
-    so an object-shaped pin is an expression object. A leaf that is only an
-    expression keeps its type ("{{ length(items) }}" -> 3); one embedded in
-    text stringifies ("Bearer {{ apiKey }}"). Data containing no braces passes
-    through untouched.
+    DATA pins take Expression(): the whole value is one JMESPath expression,
+    the same contract as the Transform block, and the result keeps its JSON
+    type — an expression building an object yields an object. A non-string
+    value came from upstream rather than the designer, so it is already data
+    and passes through untouched.
 
     Evaluation always runs, context or not: literal-only templates work with
     nothing wired, expressions evaluate against an empty document (missing
@@ -257,7 +215,7 @@ class TemplatableBlock(Block):
                 continue
             try:
                 result = _eval_expression(raw, self.context)
-            except (JMESPathError, ExpressionError) as e:
+            except JMESPathError as e:
                 raise BlockError(
                     f"Expression evaluation failed for '{field_name}': {e}. "
                     f"{_EXPRESSION_HINT}"
@@ -281,7 +239,7 @@ class TemplatableBlock(Block):
             else:
                 try:
                     value = _eval_expression(raw, self.context)
-                except (JMESPathError, ExpressionError) as e:
+                except JMESPathError as e:
                     raise BlockError(
                         f"Expression evaluation failed for '{port_name}.{pin_name}': "
                         f"{e}. {_EXPRESSION_HINT}"

--- a/smartspace/tests/test_templatable.py
+++ b/smartspace/tests/test_templatable.py
@@ -130,7 +130,7 @@ def test_templatable_autojson_full_object_serialises():
 def test_expression_evaluates_jmespath():
     block = SimpleExpression()
     block._set_inputs([
-        _iv("condition", "", "{{ user.active }}"),
+        _iv("condition", "", "user.active"),
         _context_iv("user", {"active": True}),
     ])
     assert block.condition is True
@@ -139,7 +139,7 @@ def test_expression_evaluates_jmespath():
 def test_expression_returns_typed_value():
     block = SimpleExpression()
     block._set_inputs([
-        _iv("condition", "", "{{ length(items) }}"),
+        _iv("condition", "", "length(items)"),
         _context_iv("items", [1, 2, 3]),
     ])
     assert block.condition == 3
@@ -149,9 +149,29 @@ def test_expression_invalid_raises_block_error():
     block = SimpleExpression()
     with pytest.raises(BlockError, match="Expression evaluation failed"):
         block._set_inputs([
-            _iv("condition", "", "{{ !!!invalid!!! }}"),
+            _iv("condition", "", "!!!invalid!!!"),
             _context_iv("x", 1),
         ])
+
+
+def test_expression_has_no_brace_interpolation():
+    # The contract Transform already had, now shared: braces are not special,
+    # so a Jinja-shaped value is simply not a valid expression. Pins that are
+    # genuinely text use Templatable() instead.
+    block = SimpleExpression()
+    with pytest.raises(BlockError, match="Expression evaluation failed"):
+        block._set_inputs([
+            _iv("condition", "", "Bearer {{ apiKey }}"),
+            _context_iv("apiKey", "tok-123"),
+        ])
+
+
+def test_expression_literal_text_needs_quoting():
+    # A literal payload is expressible, but as a JMESPath raw string literal —
+    # it is no longer text that happens to contain no braces.
+    block = SimpleExpression()
+    block._set_inputs([_iv("condition", "", "'query { things }'")])
+    assert block.condition == "query { things }"
 
 
 # ---------------------------------------------------------------------------
@@ -162,10 +182,11 @@ def test_both_markers_render_independently():
     block = BothMarkers()
     block._set_inputs([
         _iv("prompt", "", "Hello {{ name }}"),
-        _iv("condition", "", "{{ score }}"),
+        _iv("condition", "", "score"),
         _context_iv("name", "Dave"),
         _context_iv("score", 42),
     ])
+    # Text pin renders Jinja; data pin evaluates JMESPath. Same context.
     assert block.prompt == "Hello Dave"
     assert block.condition == 42
 
@@ -279,85 +300,35 @@ def test_step_param_render_error_names_port_and_pin():
 def test_step_param_expression_evaluates():
     block = StepParamExpression()
     block._set_inputs([
-        _iv("run", "picked", "{{ user.name }}"),
+        _iv("run", "picked", "user.name"),
         _context_iv("user", {"name": "Erin"}),
     ])
     assert block.run._pending_inputs["picked"][""] == "Erin"
 
 
-def test_step_param_expression_object_is_evaluated():
-    # An Expression pin holds an expression wherever the value came from: a
-    # wired object is an expression object, its string leaves evaluated.
+def test_step_param_expression_builds_a_structure():
     block = StepParamExpression()
     block._set_inputs([
-        _iv("run", "picked", {"name": "{{ user.name }}", "kind": "literal"}),
-        _context_iv("user", {"name": "Erin"}),
-    ])
-    assert block.run._pending_inputs["picked"][""] == {
-        "name": "Erin",
-        "kind": "literal",
-    }
-
-
-def test_step_param_expression_nested_list_evaluated():
-    block = StepParamExpression()
-    block._set_inputs([
-        _iv("run", "picked", {"ids": ["{{ items[0].id }}", "{{ items[1].id }}"], "n": 3}),
+        _iv("run", "picked", "{ids: items[*].id, n: length(items)}"),
         _context_iv("items", [{"id": "a"}, {"id": "b"}]),
     ])
-    # Non-string scalars can't be expressions and pass through
-    assert block.run._pending_inputs["picked"][""] == {"ids": ["a", "b"], "n": 3}
-
-
-def test_step_param_expression_dict_keys_not_evaluated():
-    block = StepParamExpression()
-    block._set_inputs([
-        _iv("run", "picked", {"user": "x"}),
-        _context_iv("user", {"name": "Erin"}),
-    ])
-    assert block.run._pending_inputs["picked"][""] == {"user": "x"}
-
-
-def test_step_param_expression_literal_text_needs_no_quoting():
-    # Text outside {{ }} is never parsed, so literal payloads (GraphQL, XML)
-    # pass through as written.
-    block = StepParamExpression()
-    block._set_inputs([_iv("run", "picked", "query { things }")])
-    assert block.run._pending_inputs["picked"][""] == "query { things }"
-
-
-def test_step_param_expression_interpolates_into_text():
-    block = StepParamExpression()
-    block._set_inputs([
-        _iv("run", "picked", "Bearer {{ apiKey }}"),
-        _context_iv("apiKey", "tok-123"),
-    ])
-    assert block.run._pending_inputs["picked"][""] == "Bearer tok-123"
+    assert block.run._pending_inputs["picked"][""] == {"ids": ["a", "b"], "n": 2}
 
 
 def test_step_param_expression_whole_value_keeps_type():
     block = StepParamExpression()
     block._set_inputs([
-        _iv("run", "picked", "{{ length(items) }}"),
+        _iv("run", "picked", "length(items)"),
         _context_iv("items", [1, 2, 3]),
     ])
     value = block.run._pending_inputs["picked"][""]
     assert value == 3 and isinstance(value, int)
 
 
-def test_step_param_expression_embedded_stringifies():
-    block = StepParamExpression()
-    block._set_inputs([
-        _iv("run", "picked", "count={{ length(items) }} obj={{ user }}"),
-        _context_iv("items", [1, 2]),
-        _context_iv("user", {"a": 1}),
-    ])
-    assert block.run._pending_inputs["picked"][""] == 'count=2 obj={"a": 1}'
-
-
 def test_step_param_expression_wired_data_passes_through():
-    # The case that made us choose {{ }}: real data has no braces, so an
-    # upstream payload wired into an Expression pin is untouched.
+    # A non-string value came from upstream, not the designer — it is already
+    # the payload, so it is never compiled. This is what keeps a computed
+    # payload safe to wire into an Expression pin.
     block = StepParamExpression()
     payload = {"name": "Alice", "role": "admin", "age": 30}
     block._set_inputs([
@@ -367,44 +338,31 @@ def test_step_param_expression_wired_data_passes_through():
     assert block.run._pending_inputs["picked"][""] == payload
 
 
-def test_step_param_expression_embedded_null_raises():
-    # "Bearer null" is never what anyone meant.
+def test_step_param_expression_wired_list_passes_through():
     block = StepParamExpression()
-    with pytest.raises(BlockError, match="evaluated to null"):
-        block._set_inputs([_iv("run", "picked", "Bearer {{ apiKey }}")])
-
-
-def test_step_param_expression_empty_braces_raise():
-    block = StepParamExpression()
-    with pytest.raises(BlockError, match="Empty expression"):
-        block._set_inputs([_iv("run", "picked", "{{ }}")])
+    block._set_inputs([_iv("run", "picked", [1, 2, 3])])
+    assert block.run._pending_inputs["picked"][""] == [1, 2, 3]
 
 
 def test_step_param_expression_empty_context_missing_ref_is_null():
     block = StepParamExpression()
-    block._set_inputs([_iv("run", "picked", "{{ user.name }}")])
+    block._set_inputs([_iv("run", "picked", "user.name")])
     assert block.run._pending_inputs["picked"][""] is None
 
 
-def test_expression_class_attr_object_is_evaluated():
-    block = SimpleExpression()
-    block._set_inputs([
-        _iv("condition", "", {"a": "{{ x }}", "b": "lit", "c": True}),
-        _context_iv("x", 1),
-    ])
-    assert block.condition == {"a": 1, "b": "lit", "c": True}
-
-
 def test_expression_headers_shape_end_to_end():
-    # The motivating case: an expression object mixing a plain literal, an
-    # interpolation, and a computed value that keeps its type.
+    # The motivating case: one expression building a headers object, mixing a
+    # literal with a value computed from context. Both quoting rules appear —
+    # a hyphenated key double-quoted, literal text single-quoted.
     block = SimpleExpression()
     block._set_inputs([
-        _iv("condition", "", {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer {{ apiKey }}",
-            "X-Count": "{{ length(items) }}",
-        }),
+        _iv(
+            "condition",
+            "",
+            "{\"Content-Type\": 'application/json', "
+            "Authorization: join('', ['Bearer ', apiKey]), "
+            "\"X-Count\": length(items)}",
+        ),
         _context_iv("apiKey", "tok-123"),
         _context_iv("items", [1, 2, 3]),
     ])
@@ -413,6 +371,27 @@ def test_expression_headers_shape_end_to_end():
         "Authorization": "Bearer tok-123",
         "X-Count": 3,
     }
+
+
+def test_expression_hyphenated_key_must_be_quoted():
+    # Unquoted JMESPath identifiers are [A-Za-z_][A-Za-z0-9_]*, so a bare
+    # X-Count lexes as subtraction. Nearly every real header name has a
+    # hyphen, which makes this the mistake most worth failing loudly on.
+    block = SimpleExpression()
+    with pytest.raises(BlockError, match="Expression evaluation failed"):
+        block._set_inputs([
+            _iv("condition", "", "{X-Count: length(items)}"),
+            _context_iv("items", [1, 2, 3]),
+        ])
+
+
+def test_expression_double_quoted_value_is_a_field_lookup():
+    # The other half of the quoting rule, and the quiet one: double quotes are
+    # a field reference, so this yields null rather than the text it resembles.
+    # Consumers are expected to reject nulls with their own message.
+    block = SimpleExpression()
+    block._set_inputs([_iv("condition", "", "{\"Content-Type\": \"application/json\"}")])
+    assert block.condition == {"Content-Type": None}
 
 
 def test_step_param_dict_renders_string_leaves():


### PR DESCRIPTION
## The contradiction

`Expression()` did two things that disagreed with each other.

It stamped `language: jmespath` on the pin — which makes the designer render it as a **code editor**, whose value is a string ([config-form.builder.ts](https://github.com/Smartspace-ai/Smartspace-app/blob/develop/apps/admin/src/ui/manage-workspace/workflow-layout/components/flow/configs/config-drawer/config-form.builder.ts): *"A pin that declares a language renders as a code editor rather than a text box"*).

It then evaluated that value as **template text with `{{ }}` islands** — `_eval_expression_string` substitutes into the surrounding text, so a string leaf comes back a string.

An object typed into such a pin therefore could never evaluate to an object. That is exactly how it failed in the wild for `HTTPRequest 4.0.0`'s `headers`:

```
headers must evaluate to an object, got str: '{\n  "Authorization": "Bearer ...",\n  "Content-Type": "application/json"\n}'
```

## The fix

Transform already had the contract that works, and had it first:

```python
compiled = jmespath.compile(self.expression)
value = compiled.search(inputs)
```

`Expression()` now means the same thing — the whole pin value IS the expression, evaluated against the connected `context` inputs, result keeping its JSON type. A marked pin and a Transform pin now behave identically, which is the point: one expression contract, not two.

`_eval_expression` goes from ~50 lines to 3:

```python
def _eval_expression(raw, context):
    if not isinstance(raw, str):
        return raw                                  # wired payload — already data
    return jmespath.compile(raw).search(context)    # whole value IS the expression
```

Deleted with it: `_eval_expression_string`, `_stringify`, `ExpressionError`, both regex patterns, and the dict/list **walking**. Under whole-value semantics a non-string value came from upstream rather than the designer, so it is already data and passes through untouched — which is what keeps a computed payload safe to wire into an Expression pin. Net **-82 lines** in `templatable.py`.

`Templatable()` is untouched. The split is now stateable in one line: **TEXT pins (a URL, a prompt) are Jinja `{{ }}`; DATA pins are whole-value JMESPath.**

## Blast radius: nothing else uses it

`Expression()` had no users outside `HTTPRequest 4.0.0`, and `TemplatableBlock` has exactly one subclass. So no other block changes behaviour.

## What reviewers should push on

The quoting rule, because it is what will actually catch people out, and it means opposite things either side of the colon:

```
{X-Count: length(items)}              -> LexerError (bare hyphen lexes as subtraction)
{"X-Count": length(items)}            -> {'X-Count': 3}
{"Content-Type": 'application/json'}  -> {'Content-Type': 'application/json'}
{"Content-Type": "application/json"}  -> {'Content-Type': None}     <- quiet one
```

Keys with a hyphen need **double** quotes; literal values need **single**. Nearly every real header name has a hyphen. The unquoted-key case raises on compile; the double-quoted-value case yields null and is left for consumers to reject with their own message (the HTTP block does). `_EXPRESSION_HINT` now carries this rather than brace syntax, and both cases have tests.

Two behaviours are genuinely gone, deliberately:

- **Interpolation into text** (`"Bearer {{ apiKey }}"`) — produces text by construction, which defeats a typed expression pin. Use `join('', ['Bearer ', apiKey])`.
- **Literal text passing through unparsed** (`query { things }`) — still expressible, but as a JMESPath raw string literal: `'query { things }'`.

Both have regression tests pinning the new behaviour.

## Tests

`test_templatable.py` rewritten for the new contract — the brace-era tests asserted behaviour that no longer exists.

- `smartspace/tests/test_templatable.py` — 39 passed
- full SDK suite — **122 passed**

## Follow-up

Needs a paired ai-api change: restore `Expression()` on `HTTPRequest 4.0.0`'s `headers`/`body` and drop the block-local evaluation, plus a lock bump. That supersedes Smartspace-ai-api#897, which fixed this block-locally and should be closed in favour of the pair.